### PR TITLE
Fix MESV toggle sidebar, RefTagger navigation, and verse-range dashes

### DIFF
--- a/_pages/wcf.md
+++ b/_pages/wcf.md
@@ -13,7 +13,7 @@ layout: post
 <details class="scripture-proofs" id="wcf-1-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Rom. 2:14–15; Rom. 1:19–20; Ps. 19:1–4; Rom. 1:32–2:1, <strong>b.</strong> John 17:3; 1 Cor. 1:21; 1 Cor. 2:13–14, <strong>c.</strong> Heb. 1:1–2, <strong>d.</strong> Luke 1:3–4; Rom. 15:4; Matt. 4:4, 7, 10; Isa. 8:20, <strong>e.</strong> 2 Tim. 3:15; 2 Pet. 1:19, <strong>f.</strong> John 20:31; 1 Cor. 14:37; 1 John 5:13; 1 Cor. 10:11; Heb. 1:1–2; Heb. 2:2–4</p></div>
+<p><strong>a.</strong> Rom. 2:14-15; Rom. 1:19-20; Ps. 19:1-4; Rom. 1:32-2:1, <strong>b.</strong> John 17:3; 1 Cor. 1:21; 1 Cor. 2:13-14, <strong>c.</strong> Heb. 1:1-2, <strong>d.</strong> Luke 1:3-4; Rom. 15:4; Matt. 4:4, 7, 10; Isa. 8:20, <strong>e.</strong> 2 Tim. 3:15; 2 Pet. 1:19, <strong>f.</strong> John 20:31; 1 Cor. 14:37; 1 John 5:13; 1 Cor. 10:11; Heb. 1:1-2; Heb. 2:2-4</p></div>
 </details>
 
 <p><span id="wcf-1-2"></span>2. Under the name of Holy Scripture, or the Word of God written, are now contained all the books of the Old and New <span class="v-const">Testaments,</span><span class="v-modern">Testament,</span> which are these:</p>
@@ -52,7 +52,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-1-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>g.</strong> Luke 16:29, 31; Luke 24:27, 44; 2 Tim. 3:15–16</p>
+<p><strong>g.</strong> Luke 16:29, 31; Luke 24:27, 44; 2 Tim. 3:15-16</p>
 </div>
 </details>
 
@@ -61,7 +61,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-1-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>h.</strong> Rev. 22:18–19; Rom. 3:2; 2 Pet. 1:21</p>
+<p><strong>h.</strong> Rev. 22:18-19; Rom. 3:2; 2 Pet. 1:21</p>
 </div>
 </details>
 
@@ -70,7 +70,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-1-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>i.</strong> 2 Pet. 1:19–20; 2 Tim. 3:16; 1 John 5:9; 1 Thess. 2:13; Rev. 1:1–2; 1 Tim. 3:15</p>
+<p><strong>i.</strong> 2 Pet. 1:19-20; 2 Tim. 3:16; 1 John 5:9; 1 Thess. 2:13; Rev. 1:1-2; 1 Tim. 3:15</p>
 </div>
 </details>
 
@@ -79,7 +79,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-1-5-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> 1 Cor. 2:9–10; Heb. 4:12; John 10:35; Isa. 55:11; Rom. 11:36; Ps. 19:7–11; 2 Tim. 3:15; 1 Cor. 2:4–5; 1 Thess. 1:5; 1 John 2:20, 27; Isa. 59:21</p>
+<p><strong>l.</strong> 1 Cor. 2:9-10; Heb. 4:12; John 10:35; Isa. 55:11; Rom. 11:36; Ps. 19:7-11; 2 Tim. 3:15; 1 Cor. 2:4-5; 1 Thess. 1:5; 1 John 2:20, 27; Isa. 59:21</p>
 </div>
 </details>
 
@@ -88,7 +88,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-1-6-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>m.</strong> 2 Tim. 3:16–17; Gal. 1:8–9; 2 Thess. 2:2, <strong>n.</strong> John 6:45; 1 Cor. 2:12, 14–15; Eph. 1:18; 2 Cor. 4:6, <strong>o.</strong> 1 Cor. 11:13–14; 1 Cor. 14:26, 40</p></div>
+<p><strong>m.</strong> 2 Tim. 3:16-17; Gal. 1:8-9; 2 Thess. 2:2, <strong>n.</strong> John 6:45; 1 Cor. 2:12, 14-15; Eph. 1:18; 2 Cor. 4:6, <strong>o.</strong> 1 Cor. 11:13-14; 1 Cor. 14:26, 40</p></div>
 </details>
 
 <p><span id="wcf-1-7"></span>7. All things in Scripture are not alike plain in themselves, nor alike clear <span class="v-const">unto</span><span class="v-modern">to</span> all:<sup class="proof-marker">p</sup> yet those things which are necessary to be known, believed, and observed for salvation, are so clearly propounded, and opened in some place of Scripture or other, that not only the learned, but the unlearned, in a due use of the ordinary means, may attain <span class="v-const">unto</span><span class="v-modern">to</span> a sufficient understanding of them.<sup class="proof-marker">q</sup></p>
@@ -96,7 +96,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-1-7-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>p.</strong> 2 Pet. 3:16, <strong>q.</strong> Ps. 119:105, 130; Deut. 29:29; Deut. 30:10–14; Acts 17:11</p></div>
+<p><strong>p.</strong> 2 Pet. 3:16, <strong>q.</strong> Ps. 119:105, 130; Deut. 29:29; Deut. 30:10-14; Acts 17:11</p></div>
 </details>
 
 <p><span id="wcf-1-8"></span>8. The Old Testament in Hebrew (which was the native language of the people of God of old), and the New Testament in Greek (which, at the time of the writing of it, was most generally known to the nations), being immediately inspired by God, and, by his singular care and providence, kept pure in all ages, are therefore <span class="v-const">authentical;</span><span class="v-modern">authentic;</span><sup class="proof-marker">r</sup> so <span class="v-const">as,</span><span class="v-modern">that,</span> in all controversies of religion, the church is finally to appeal <span class="v-const">unto</span><span class="v-modern">to</span> them.<sup class="proof-marker">s</sup> But, because these original tongues are not known to all the people of God, who have right <span class="v-const">unto,</span><span class="v-modern">to,</span> and interest in the Scriptures, and are commanded, in the fear of God, to read and search them,<sup class="proof-marker">t</sup> therefore they are to be translated into the <span class="v-const">vulgar</span><span class="v-modern">common</span> language of every nation <span class="v-const">unto</span><span class="v-modern">to</span> which they come,<sup class="proof-marker">u</sup> that, the Word of God dwelling plentifully in all, they may worship him in an acceptable manner;<sup class="proof-marker">w</sup> and, through patience and comfort of the Scriptures, may have hope.<sup class="proof-marker">x</sup></p>
@@ -104,7 +104,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-1-8-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>r.</strong> Matt. 5:18; Ps. 119:89, <strong>s.</strong> Isa. 8:20; Matt. 15:3, 6; Acts 15:15; Luke 16:31, <strong>t.</strong> John 5:39; Acts 17:11; Rev. 1:3; 2 Tim. 3:14–15, <strong>u.</strong> Matt. 28:19–20; 1 Cor. 14:6; Mark 15:34, <strong>w.</strong> Col. 3:16; Matt. 15:7–9, <strong>x.</strong> Rom. 15:4</p></div>
+<p><strong>r.</strong> Matt. 5:18; Ps. 119:89, <strong>s.</strong> Isa. 8:20; Matt. 15:3, 6; Acts 15:15; Luke 16:31, <strong>t.</strong> John 5:39; Acts 17:11; Rev. 1:3; 2 Tim. 3:14-15, <strong>u.</strong> Matt. 28:19-20; 1 Cor. 14:6; Mark 15:34, <strong>w.</strong> Col. 3:16; Matt. 15:7-9, <strong>x.</strong> Rom. 15:4</p></div>
 </details>
 
 <p><span id="wcf-1-9"></span>9. The infallible rule of interpretation of Scripture is <span class="v-const">th</span><span class="v-modern">the</span>e Scripture itself: and therefore, when there is a question about the true and full sense of any Scripture (which is not manifold, but one), it must be searched and known by other places that speak more clearly.<sup class="proof-marker">y</sup></p>
@@ -131,7 +131,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-2-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Jer. 10:10; John 5:26, <strong>b.</strong> Acts 7:2, <strong>c.</strong> Ps. 119:68, <strong>d.</strong> 1 Tim. 6:15; Rom. 9:5, <strong>e.</strong> Acts 17:24–25, <strong>f.</strong> Luke 17:10, <strong>g.</strong> Rom. 11:36, <strong>h.</strong> Rev. 4:11; Dan. 4:25, 35; 1 Tim. 6:15, <strong>i.</strong> Heb. 4:13; Rom. 11:33–34; Ps. 147:5, <strong>l.</strong> Acts 15:18; Ezek. 11:5, <strong>m.</strong> Ps. 145:17; Rom. 7:12, <strong>n.</strong> Rev. 5:12–14, <strong>o.</strong> Isa. 6:3; Rev. 4:8, <strong>p.</strong> Ps. 115:3; Isa. 14:24, <strong>q.</strong> Isa. 45:5–6, <strong>r.</strong> Eph. 1:11, <strong>s.</strong> Prov. 16:4, <strong>t.</strong> 1 John 4:8; 1 John 4:16; John 3:16, <strong>w.</strong> Heb. 11:6, <strong>x.</strong> Neh. 9:32–33; Heb. 10:28–31, <strong>y.</strong> Rom. 1:18; Ps. 5:5–6; Ps. 11:5, <strong>z.</strong> Nah. 1:2–3, 6</p></div>
+<p><strong>a.</strong> Jer. 10:10; John 5:26, <strong>b.</strong> Acts 7:2, <strong>c.</strong> Ps. 119:68, <strong>d.</strong> 1 Tim. 6:15; Rom. 9:5, <strong>e.</strong> Acts 17:24-25, <strong>f.</strong> Luke 17:10, <strong>g.</strong> Rom. 11:36, <strong>h.</strong> Rev. 4:11; Dan. 4:25, 35; 1 Tim. 6:15, <strong>i.</strong> Heb. 4:13; Rom. 11:33-34; Ps. 147:5, <strong>l.</strong> Acts 15:18; Ezek. 11:5, <strong>m.</strong> Ps. 145:17; Rom. 7:12, <strong>n.</strong> Rev. 5:12-14, <strong>o.</strong> Isa. 6:3; Rev. 4:8, <strong>p.</strong> Ps. 115:3; Isa. 14:24, <strong>q.</strong> Isa. 45:5-6, <strong>r.</strong> Eph. 1:11, <strong>s.</strong> Prov. 16:4, <strong>t.</strong> 1 John 4:8; 1 John 4:16; John 3:16, <strong>w.</strong> Heb. 11:6, <strong>x.</strong> Neh. 9:32-33; Heb. 10:28-31, <strong>y.</strong> Rom. 1:18; Ps. 5:5-6; Ps. 11:5, <strong>z.</strong> Nah. 1:2-3, 6</p></div>
 </details>
 
 <p><span id="wcf-2-2"></span>2. God <span class="v-const">hath</span><span class="v-modern">has</span> all life,<sup class="proof-marker">a</sup> glory,<sup class="proof-marker">b</sup> goodness,<sup class="proof-marker">c</sup> blessedness,<sup class="proof-marker">d</sup> in and of himself; and is alone in and <span class="v-const">unto</span><span class="v-modern">to</span> himself all-sufficient, not standing in need of any creatures <span class="v-const">which</span><span class="v-modern">that</span> he <span class="v-const">hath</span><span class="v-modern">has</span> made,<sup class="proof-marker">e</sup> nor deriving any glory from them,<sup class="proof-marker">f</sup> but only manifesting his own glory in, by, <span class="v-const">unto,</span><span class="v-modern">to,</span> and upon them. He is the alone fountain of all being, of whom, through whom, and to whom are all things;<sup class="proof-marker">g</sup> and <span class="v-const">hath</span><span class="v-modern">has</span> most sovereign dominion over them, to do by them, for them, or upon them <span class="v-const">whatsoever himself pleaseth.</span><span class="v-modern">whatever he pleases.</span><sup class="proof-marker">h</sup> In his sight all things are open and manifest,<sup class="proof-marker">i</sup> his knowledge is infinite, infallible, and independent <span class="v-const">upon</span><span class="v-modern">of</span> the creature, so <span class="v-const">as</span><span class="v-modern">that</span> nothing is to him contingent, or uncertain.<sup class="proof-marker">l</sup> He is most holy in all his counsels, in all his works, and in all his commands.<sup class="proof-marker">m</sup> To him is due from angels and men, and every other creature, <span class="v-const">whatsoever</span><span class="v-modern">whatever</span> worship, service, or obedience he is pleased to require of them.<sup class="proof-marker">n</sup></p>
@@ -139,7 +139,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-2-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Jer. 10:10; John 5:26, <strong>b.</strong> Acts 7:2, <strong>c.</strong> Ps. 119:68, <strong>d.</strong> 1 Tim. 6:15; Rom. 9:5, <strong>e.</strong> Acts 17:24–25, <strong>f.</strong> Luke 17:10, <strong>g.</strong> Rom. 11:36, <strong>h.</strong> Rev. 4:11; Dan. 4:25, 35; 1 Tim. 6:15, <strong>i.</strong> Heb. 4:13; Rom. 11:33–34; Ps. 147:5, <strong>l.</strong> Acts 15:18; Ezek. 11:5, <strong>m.</strong> Ps. 145:17; Rom. 7:12, <strong>n.</strong> Rev. 5:12–14</p></div>
+<p><strong>a.</strong> Jer. 10:10; John 5:26, <strong>b.</strong> Acts 7:2, <strong>c.</strong> Ps. 119:68, <strong>d.</strong> 1 Tim. 6:15; Rom. 9:5, <strong>e.</strong> Acts 17:24-25, <strong>f.</strong> Luke 17:10, <strong>g.</strong> Rom. 11:36, <strong>h.</strong> Rev. 4:11; Dan. 4:25, 35; 1 Tim. 6:15, <strong>i.</strong> Heb. 4:13; Rom. 11:33-34; Ps. 147:5, <strong>l.</strong> Acts 15:18; Ezek. 11:5, <strong>m.</strong> Ps. 145:17; Rom. 7:12, <strong>n.</strong> Rev. 5:12-14</p></div>
 </details>
 
 <p><span id="wcf-2-3"></span>3. In the unity of the Godhead there <span class="v-const">be</span><span class="v-modern">are</span> three persons, of one substance, power, and eternity: God the Father, God the Son, and God the Holy <span class="v-const"><span class="v-const">Ghost:</span><span class="v-modern">Spirit</span></span><span class="v-modern">Spirit:</span><sup class="proof-marker">o</sup> the Father is of none, neither begotten, nor proceeding; the Son is eternally begotten of the Father;<sup class="proof-marker">p</sup> the Holy Ghost eternally proceeding from the Father and the Son.<sup class="proof-marker">q</sup></p>
@@ -147,7 +147,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-2-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>o.</strong> Isa. 6:3; Rev. 4:8, <strong>p.</strong> Ps. 115:3; Isa. 14:24, <strong>q.</strong> Isa. 45:5–6</p></div>
+<p><strong>o.</strong> Isa. 6:3; Rev. 4:8, <strong>p.</strong> Ps. 115:3; Isa. 14:24, <strong>q.</strong> Isa. 45:5-6</p></div>
 </details>
 
 ## CHAPTER 3: Of God's Eternal Decree
@@ -164,7 +164,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-3-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>d.</strong> 1 Sam. 23:11–12; Matt. 11:21, 23, <strong>e.</strong> Rom. 9:11, 13, 16, 18</p></div>
+<p><strong>d.</strong> 1 Sam. 23:11-12; Matt. 11:21, 23, <strong>e.</strong> Rom. 9:11, 13, 16, 18</p></div>
 </details>
 
 <p><span id="wcf-3-3"></span>3. By the decree of God, for the manifestation of his glory, some men and angels are <span class="v-const">predestinated unto</span><span class="v-modern">predestined to</span> everlasting life; and others foreordained to everlasting death.<sup class="proof-marker">g</sup></p>
@@ -172,7 +172,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-3-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>g.</strong> Eph. 1:5–6; Rom. 9:22–23</p>
+<p><strong>g.</strong> Eph. 1:5-6; Rom. 9:22-23</p>
 </div>
 </details>
 
@@ -181,7 +181,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-3-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>h.</strong> John 13:18; 2 Tim. 2:19; John 10:14–16, 27–28</p>
+<p><strong>h.</strong> John 13:18; 2 Tim. 2:19; John 10:14-16, 27-28</p>
 </div>
 </details>
 
@@ -190,7 +190,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-3-5-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>i.</strong> Eph. 1:4, 9, 11; Rom. 8:28–30; 2 Tim. 1:9; 1 Thess. 5:9; Rom. 9:11, 13, 15–16; Eph. 2:8–9; Eph. 1:5, 9, 11, <strong>l.</strong> Eph. 1:6, 12</p></div>
+<p><strong>i.</strong> Eph. 1:4, 9, 11; Rom. 8:28-30; 2 Tim. 1:9; 1 Thess. 5:9; Rom. 9:11, 13, 15-16; Eph. 2:8-9; Eph. 1:5, 9, 11, <strong>l.</strong> Eph. 1:6, 12</p></div>
 </details>
 
 <p><span id="wcf-3-6"></span>6. As God <span class="v-const">hath</span><span class="v-modern">has</span> appointed the elect <span class="v-const">unto</span><span class="v-modern">to</span> glory, so <span class="v-const">hath he,</span><span class="v-modern">he has,</span> by the eternal and most free purpose of his will, foreordained all the means thereunto.<sup class="proof-marker">m</sup> Wherefore, they who are elected, being fallen in Adam, are redeemed by Christ,<sup class="proof-marker">n</sup> are effectually called <span class="v-const">unto</span><span class="v-modern">to</span> faith in Christ by his Spirit working in due season, are justified, adopted, sanctified,<sup class="proof-marker">o</sup> and kept by his power, through faith, <span class="v-const">unto</span><span class="v-modern">to</span> salvation.<sup class="proof-marker">p</sup> Neither are any other redeemed by Christ, effectually called, justified, adopted, sanctified, and saved, but the elect only.<sup class="proof-marker">q</sup></p>
@@ -198,7 +198,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-3-6-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>m.</strong> 1 Pet. 1:2; Eph. 2:10; 2 Thess. 2:13, <strong>n.</strong> 1 Thess. 5:9–10, <strong>o.</strong> Rom. 8:30; Eph. 1:5; 2 Thess. 2:13, <strong>p.</strong> 1 Pet. 1:5, <strong>q.</strong> John 10:14–15, 26; John 6:64–65; Rom. 8:28–39</p></div>
+<p><strong>m.</strong> 1 Pet. 1:2; Eph. 2:10; 2 Thess. 2:13, <strong>n.</strong> 1 Thess. 5:9-10, <strong>o.</strong> Rom. 8:30; Eph. 1:5; 2 Thess. 2:13, <strong>p.</strong> 1 Pet. 1:5, <strong>q.</strong> John 10:14-15, 26; John 6:64-65; Rom. 8:28-39</p></div>
 </details>
 
 <p><span id="wcf-3-7"></span>7. The rest of mankind God was pleased, according to the unsearchable counsel of his own will, <span class="v-const">whereby</span><span class="v-modern">by which</span> he <span class="v-const">extendeth</span><span class="v-modern">extends</span> or <span class="v-const">withholdeth</span><span class="v-modern">withholds</span> mercy, as he <span class="v-const">pleaseth,</span><span class="v-modern">pleases,</span> for the glory of his sovereign power over his creatures, to pass by; and to ordain them to dishonor and wrath for their sin, to the praise of his glorious justice.<sup class="proof-marker">r</sup></p>
@@ -206,7 +206,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-3-7-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>r.</strong> Matt. 11:25–26; Rom. 9:17–18, 21–22; 1 Pet. 2:8; 2 Tim. 2:19–20</p>
+<p><strong>r.</strong> Matt. 11:25-26; Rom. 9:17-18, 21-22; 1 Pet. 2:8; 2 Tim. 2:19-20</p>
 </div>
 </details>
 
@@ -215,7 +215,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-3-8-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>s.</strong> Rom. 9:20; Rom. 11:33; Deut. 29:29, <strong>t.</strong> 2 Pet. 1:10; 1 Thess. 1:4–5</p></div>
+<p><strong>s.</strong> Rom. 9:20; Rom. 11:33; Deut. 29:29, <strong>t.</strong> 2 Pet. 1:10; 1 Thess. 1:4-5</p></div>
 </details>
 
 ## CHAPTER 4: Of Creation
@@ -224,7 +224,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-4-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Rom. 11:36; 1 Cor. 8:6; Heb. 1:2; John 1:2–3; Gen. 1:2; Job 33:4, <strong>b.</strong> Rom. 1:20; Jer. 10:12; Ps. 104:24; Ps. 33:5, <strong>c.</strong> Gen. 1:1–31</p></div>
+<p><strong>a.</strong> Rom. 11:36; 1 Cor. 8:6; Heb. 1:2; John 1:2-3; Gen. 1:2; Job 33:4, <strong>b.</strong> Rom. 1:20; Jer. 10:12; Ps. 104:24; Ps. 33:5, <strong>c.</strong> Gen. 1:1-31</p></div>
 </details>
 
 <p><span id="wcf-4-2"></span>2. After God had made all other creatures, he created man, male and female,<sup class="proof-marker">d</sup> with reasonable and immortal souls,<sup class="proof-marker">e</sup> endued with knowledge, righteousness, and true holiness, after his own image;<sup class="proof-marker">f</sup> having the law of God written in their hearts,<sup class="proof-marker">g</sup> and power to fulfill it:<sup class="proof-marker">h</sup> and yet under a possibility of transgressing, being left to the liberty of their own will, which was subject <span class="v-const">unto</span><span class="v-modern">to</span> change.<sup class="proof-marker">i</sup> Beside this law written in their hearts, they received a command, not to eat of the tree of the knowledge of good and evil; <span class="v-const">which</span> while they <span class="v-const">kept,</span><span class="v-modern">kept it,</span> they were happy in their communion with God, and had dominion over the creatures.<sup class="proof-marker">l</sup></p>
@@ -232,7 +232,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-4-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>d.</strong> Gen. 1:27, <strong>e.</strong> Gen. 2:7; Luke 23:43; Matt. 10:28, <strong>f.</strong> Gen. 1:26; Col. 3:10; Eph. 4:24, <strong>g.</strong> Rom. 2:14–15, <strong>h.</strong> Gen. 2:17</p></div>
+<p><strong>d.</strong> Gen. 1:27, <strong>e.</strong> Gen. 2:7; Luke 23:43; Matt. 10:28, <strong>f.</strong> Gen. 1:26; Col. 3:10; Eph. 4:24, <strong>g.</strong> Rom. 2:14-15, <strong>h.</strong> Gen. 2:17</p></div>
 </details>
 
 ## CHAPTER 5: Of Providence
@@ -241,7 +241,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-5-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Ps. 109:6; Luke 22:3; 2 Thess. 2:10–12, <strong>b.</strong> 2 Cor. 2:15–16; Isa. 8:14; 1 Pet. 2:7–8; Isa. 6:9–10; Acts 28:26–27, <strong>c.</strong> 1 Tim. 4:10; Amos 9:8–9; Matt. 16:18; Rom. 8:28; Isa. 43:3–5, 14, <strong>d.</strong> Prov. 15:3; 2 Chron. 16:9; Ps. 104:24; Ps. 145:17, <strong>e.</strong> Acts 15:18; Isa. 42:9; Ezek. 11:5, <strong>f.</strong> Eph. 1:11; Ps. 33:10–11, <strong>g.</strong> Isa. 63:14; Eph. 3:10; Rom. 9:17; Gen. 45:7; Ps. 145:7</p></div>
+<p><strong>a.</strong> Ps. 109:6; Luke 22:3; 2 Thess. 2:10-12, <strong>b.</strong> 2 Cor. 2:15-16; Isa. 8:14; 1 Pet. 2:7-8; Isa. 6:9-10; Acts 28:26-27, <strong>c.</strong> 1 Tim. 4:10; Amos 9:8-9; Matt. 16:18; Rom. 8:28; Isa. 43:3-5, 14, <strong>d.</strong> Prov. 15:3; 2 Chron. 16:9; Ps. 104:24; Ps. 145:17, <strong>e.</strong> Acts 15:18; Isa. 42:9; Ezek. 11:5, <strong>f.</strong> Eph. 1:11; Ps. 33:10-11, <strong>g.</strong> Isa. 63:14; Eph. 3:10; Rom. 9:17; Gen. 45:7; Ps. 145:7</p></div>
 </details>
 
 <p><span id="wcf-5-2"></span>2. Although, in relation to the foreknowledge and decree of God, the <span class="v-const">first</span><span class="v-modern">First</span> Cause, all things come to pass immutably, and infallibly;<sup class="proof-marker">h</sup> yet, by the same providence, he <span class="v-const">ordereth</span><span class="v-modern">orders</span> them to <span class="v-const">fall out,</span><span class="v-modern">come about,</span> according to the nature of second causes, either necessarily, freely, or contingently.<sup class="proof-marker">i</sup></p>
@@ -249,7 +249,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-5-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>h.</strong> Acts 2:23; Isa. 14:24, 27, <strong>i.</strong> Gen. 8:22; Jer. 31:35; Isa. 10:6–7; Deut. 19:5; 1 Kings 22:28–34; Acts 27:24, 31, 44b; Isa. 55:10–11</p></div>
+<p><strong>h.</strong> Acts 2:23; Isa. 14:24, 27, <strong>i.</strong> Gen. 8:22; Jer. 31:35; Isa. 10:6-7; Deut. 19:5; 1 Kings 22:28-34; Acts 27:24, 31, 44b; Isa. 55:10-11</p></div>
 </details>
 
 <p><span id="wcf-5-3"></span>3. God, in his ordinary providence, <span class="v-const">maketh</span><span class="v-modern">makes</span> use of means, yet is free to work without,<sup class="proof-marker">l</sup> above,<sup class="proof-marker">m</sup> and against them, at his pleasure.<sup class="proof-marker">n</sup></p>
@@ -257,7 +257,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-5-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Hos. 1:7; Matt. 4:4; Job 34:20, <strong>m.</strong> Rom. 4:19–21, <strong>n.</strong> 2 Kings 6:6; Dan. 3:27</p></div>
+<p><strong>l.</strong> Hos. 1:7; Matt. 4:4; Job 34:20, <strong>m.</strong> Rom. 4:19-21, <strong>n.</strong> 2 Kings 6:6; Dan. 3:27</p></div>
 </details>
 
 <p><span id="wcf-5-4"></span>4. The almighty power, unsearchable wisdom, and infinite goodness of God so far manifest themselves in his providence, that it <span class="v-const">extendeth</span><span class="v-modern">extends</span> itself even to the first fall, and all other sins of angels and men;<sup class="proof-marker">o</sup> and that not by a bare permission,<sup class="proof-marker">p</sup> but such as <span class="v-const">hath</span><span class="v-modern">has</span> joined with it a most wise and powerful <span class="v-const">bounding,</span><span class="v-modern">limiting,</span><sup class="proof-marker">q</sup> and otherwise ordering, and governing of them, in a manifold dispensation, to his own holy ends;<sup class="proof-marker">r</sup> yet <span class="v-const">so, as the</span><span class="v-modern">so that their</span> sinfulness <span class="v-const">thereof proceedeth</span><span class="v-modern">proceeds</span> only from the creature, and not from God, who, being most holy and righteous, neither is nor can be the author or approver of sin.<sup class="proof-marker">s</sup></p>
@@ -265,7 +265,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-5-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>o.</strong> Isa. 45:7; Rom. 11:32–34; 2 Sam. 16:10; Acts 2:23; Acts 4:27–28; 2 Sam. 24:1; 1 Chron. 21:1; 1 Kings 22:22–23; 1 Chron. 10:4, 13–14, <strong>p.</strong> John 12:40; 2 Thess. 2:11, <strong>q.</strong> Ps. 76:10; 2 Kings 19:28, <strong>r.</strong> Gen. 50:20; Isa. 10:12; Isa. 10:6–7, 13–15, <strong>s.</strong> 1 John 2:16; Ps. 50:21</p></div>
+<p><strong>o.</strong> Isa. 45:7; Rom. 11:32-34; 2 Sam. 16:10; Acts 2:23; Acts 4:27-28; 2 Sam. 24:1; 1 Chron. 21:1; 1 Kings 22:22-23; 1 Chron. 10:4, 13-14, <strong>p.</strong> John 12:40; 2 Thess. 2:11, <strong>q.</strong> Ps. 76:10; 2 Kings 19:28, <strong>r.</strong> Gen. 50:20; Isa. 10:12; Isa. 10:6-7, 13-15, <strong>s.</strong> 1 John 2:16; Ps. 50:21</p></div>
 </details>
 
 <p><span id="wcf-5-5"></span>5. The most wise, righteous, and gracious God <span class="v-const">doth oftentimes leave,</span><span class="v-modern">often leaves his own children,</span> for a season, <span class="v-const">his own children</span> to manifold temptations, and the corruption of their own hearts, to chastise them for their former sins, or to <span class="v-const">discover unto</span><span class="v-modern">expose to</span> them the hidden strength of corruption and deceitfulness of their hearts, that they may be humbled;<sup class="proof-marker">t</sup> and, to raise them to a more close and constant dependence for their support upon himself, and to make them more watchful against all future occasions of sin, and for <span class="v-const">sundry</span><span class="v-modern">various</span> other just and holy ends.<sup class="proof-marker">u</sup></p>
@@ -273,7 +273,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-5-5-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>t.</strong> 2 Chron. 32:25–26, 31; Deut. 8:2–3, 5; Luke 22:31–32; 2 Sam. 24:1, 25, <strong>u.</strong> 2 Cor. 12:7–9; Ps. 73:1–28; Mark 14:66–72; John 21:15–19</p></div>
+<p><strong>t.</strong> 2 Chron. 32:25-26, 31; Deut. 8:2-3, 5; Luke 22:31-32; 2 Sam. 24:1, 25, <strong>u.</strong> 2 Cor. 12:7-9; Ps. 73:1-28; Mark 14:66-72; John 21:15-19</p></div>
 </details>
 
 <p><span id="wcf-5-6"></span>6. As for those wicked and ungodly men whom God, as a righteous Judge, <span class="v-modern">blinds and hardens</span> for former sins, <span class="v-const">doth blind and harden,</span><sup class="proof-marker">w</sup> from them he not only <span class="v-const">withholdeth</span><span class="v-modern">withholds</span> his grace <span class="v-const"><span class="v-const">whereby</span><span class="v-modern">by which</span></span><span class="v-modern">by which</span> they might have been enlightened in their understandings, and wrought upon in their hearts;<sup class="proof-marker">x</sup> but sometimes also <span class="v-const">withdraweth</span><span class="v-modern">withdraws</span> the gifts <span class="v-const">which</span><span class="v-modern">that</span> they had,<sup class="proof-marker">y</sup> and <span class="v-const">exposeth</span><span class="v-modern">exposes</span> them to such objects as their corruption makes occasions of sin;<sup class="proof-marker">z</sup> and, <span class="v-const">withal,</span><span class="v-modern">additionally,</span> gives them over to their own lusts, the temptations of the world, and the power of Satan,<sup class="proof-marker">a</sup> whereby it comes to pass that they harden themselves, even under those means <span class="v-const">which</span><span class="v-modern">that</span> God <span class="v-const">useth</span><span class="v-modern">uses</span> for the softening of others.<sup class="proof-marker">b</sup></p>
@@ -281,7 +281,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-5-6-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Ps. 109:6; Luke 22:3; 2 Thess. 2:10–12, <strong>b.</strong> 2 Cor. 2:15–16; Isa. 8:14; 1 Pet. 2:7–8; Isa. 6:9–10; Acts 28:26–27, <strong>w.</strong> Rom. 1:24, 26, 28; Rom. 11:7–8, <strong>x.</strong> Deut. 29:4; Mark 4:11–12, <strong>y.</strong> Matt. 13:12; Matt. 25:29; Acts 13:10–11, <strong>z.</strong> Gen. 4:8; 2 Kings 8:12–13; Matt. 26:14–16</p></div>
+<p><strong>a.</strong> Ps. 109:6; Luke 22:3; 2 Thess. 2:10-12, <strong>b.</strong> 2 Cor. 2:15-16; Isa. 8:14; 1 Pet. 2:7-8; Isa. 6:9-10; Acts 28:26-27, <strong>w.</strong> Rom. 1:24, 26, 28; Rom. 11:7-8, <strong>x.</strong> Deut. 29:4; Mark 4:11-12, <strong>y.</strong> Matt. 13:12; Matt. 25:29; Acts 13:10-11, <strong>z.</strong> Gen. 4:8; 2 Kings 8:12-13; Matt. 26:14-16</p></div>
 </details>
 
 <p><span id="wcf-5-7"></span>7. As the providence of <span class="v-const">God doth,</span><span class="v-modern">God,</span> in general, <span class="v-const">reach</span><span class="v-modern">reaches</span> to all creatures; so, <span class="v-const">after</span><span class="v-modern">in</span> a most special manner, it <span class="v-const">taketh</span><span class="v-modern">takes</span> care of his church, and <span class="v-const">disposeth</span><span class="v-modern">orders</span> all things to <span class="v-const">the good thereof.</span><span class="v-modern">its good.</span><sup class="proof-marker">c</sup></p>
@@ -289,7 +289,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-5-7-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>c.</strong> 1 Tim. 4:10; Amos 9:8–9; Matt. 16:18; Rom. 8:28; Isa. 43:3–5, 14</p>
+<p><strong>c.</strong> 1 Tim. 4:10; Amos 9:8-9; Matt. 16:18; Rom. 8:28; Isa. 43:3-5, 14</p>
 </div>
 </details>
 
@@ -308,7 +308,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-6-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>c.</strong> Gen. 3:6–8; Rom. 3:23, <strong>d.</strong> Gen. 2:17; Eph. 2:1–3; Rom. 5:12, <strong>e.</strong> Gen. 6:5; Jer. 17:9; Rom. 3:10–19</p></div>
+<p><strong>c.</strong> Gen. 3:6-8; Rom. 3:23, <strong>d.</strong> Gen. 2:17; Eph. 2:1-3; Rom. 5:12, <strong>e.</strong> Gen. 6:5; Jer. 17:9; Rom. 3:10-19</p></div>
 </details>
 
 <p><span id="wcf-6-3"></span>3. They being the root of all mankind, the guilt of this sin was imputed;<sup class="proof-marker">f</sup> and the same death in sin, and corrupted nature, conveyed to all their posterity descending from them by ordinary generation.<sup class="proof-marker">g</sup></p>
@@ -316,7 +316,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-6-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>f.</strong> Acts 17:26; Rom. 5:12, 15–19; 1 Cor. 15:21–22, 49, <strong>g.</strong> Ps. 51:5; John 3:6; Gen. 5:3; Job 15:14</p></div>
+<p><strong>f.</strong> Acts 17:26; Rom. 5:12, 15-19; 1 Cor. 15:21-22, 49, <strong>g.</strong> Ps. 51:5; John 3:6; Gen. 5:3; Job 15:14</p></div>
 </details>
 
 <p><span id="wcf-6-4"></span>4. From this original corruption, <span class="v-const">whereby</span><span class="v-modern">by which</span> we are utterly indisposed, disabled, and made opposite to all good,<sup class="proof-marker">h</sup> and wholly inclined to all evil,<sup class="proof-marker">i</sup> <span class="v-const">do</span> proceed all actual transgressions.</p>
@@ -324,7 +324,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-6-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>h.</strong> Rom. 5:6; Rom. 7:18; Rom. 8:7; Col. 1:21, <strong>i.</strong> Gen. 8:21; Gen. 6:5; Rom. 3:10–12; Matt. 15:19</p></div>
+<p><strong>h.</strong> Rom. 5:6; Rom. 7:18; Rom. 8:7; Col. 1:21, <strong>i.</strong> Gen. 8:21; Gen. 6:5; Rom. 3:10-12; Matt. 15:19</p></div>
 </details>
 
 <p><span id="wcf-6-5"></span>5. This corruption of nature, during this life, <span class="v-const">doth remain</span><span class="v-modern">remains</span> in those that are regenerated;<sup class="proof-marker">l</sup> and although it <span class="v-const">be,</span><span class="v-modern">is pardoned and mortified</span> through <span class="v-const">Christ, pardoned, and mortified;</span><span class="v-modern">Christ;</span> yet both itself, and all <span class="v-const">the motions thereof,</span><span class="v-modern">its motions,</span> are truly and properly sin.<sup class="proof-marker">m</sup></p>
@@ -332,7 +332,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-6-5-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Prov. 20:9; Rom. 7:14, 17–18, 21–23; 1 John 1:8, 10, <strong>m.</strong> Rom. 7:7–8, 25; Gal. 5:17</p></div>
+<p><strong>l.</strong> Prov. 20:9; Rom. 7:14, 17-18, 21-23; 1 John 1:8, 10, <strong>m.</strong> Rom. 7:7-8, 25; Gal. 5:17</p></div>
 </details>
 
 <p><span id="wcf-6-6"></span>6. Every sin, both original and actual, being a transgression of the righteous law of God, and contrary thereunto,<sup class="proof-marker">n</sup> doth, in its <span class="v-const">own nature, bring</span><span class="v-modern">nature brings</span> guilt upon the sinner,<sup class="proof-marker">o</sup> <span class="v-const">whereby</span><span class="v-modern">by which</span> he is bound over to the wrath of God,<sup class="proof-marker">p</sup> and curse of the law,<sup class="proof-marker">q</sup> and so made subject to death,<sup class="proof-marker">r</sup> with all miseries spiritual,<sup class="proof-marker">s</sup> temporal,<sup class="proof-marker">t</sup> and eternal.<sup class="proof-marker">u</sup></p>
@@ -349,7 +349,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-7-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Isa. 40:13–17; Job 9:32–33; Ps. 113:5–6; Job 22:2–3</p>
+<p><strong>a.</strong> Isa. 40:13-17; Job 9:32-33; Ps. 113:5-6; Job 22:2-3</p>
 </div>
 </details>
 
@@ -358,7 +358,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-7-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>b.</strong> Gen. 2:16–17; Hos. 6:7; Gal. 3:12, <strong>c.</strong> Gen. 3:22; Rom. 10:5; Rom. 5:12–14; Rom. 5:15–20, <strong>d.</strong> Gen. 2:17; Gal. 3:10</p></div>
+<p><strong>b.</strong> Gen. 2:16-17; Hos. 6:7; Gal. 3:12, <strong>c.</strong> Gen. 3:22; Rom. 10:5; Rom. 5:12-14; Rom. 5:15-20, <strong>d.</strong> Gen. 2:17; Gal. 3:10</p></div>
 </details>
 
 <p><span id="wcf-7-3"></span>3. Man, by his fall, having made himself incapable of life by that covenant, the Lord was pleased to make a second,<sup class="proof-marker">e</sup> commonly called the covenant of grace; <span class="v-const">wherein</span><span class="v-modern">in which</span> he freely <span class="v-const">offereth unto</span><span class="v-modern">offers to</span> sinners life and salvation by Jesus Christ; requiring of them faith in him, that they may be saved,<sup class="proof-marker">f</sup> and promising to give <span class="v-const">unto</span><span class="v-modern">to</span> all those that are ordained <span class="v-const">unto</span><span class="v-modern">to</span> eternal life his Holy Spirit, to make them willing, and able to believe.<sup class="proof-marker">g</sup></p>
@@ -366,7 +366,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-7-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>e.</strong> Gal. 3:21; Rom. 3:20–21; Rom. 8:3; Gen. 3:15; Isa. 42:6, <strong>f.</strong> John 3:16; Rom. 10:6, 9; Rev. 22:17, <strong>g.</strong> Acts 13:48; Ezek. 36:26–27; John 6:37, 44–45; 1 Cor. 12:3</p></div>
+<p><strong>e.</strong> Gal. 3:21; Rom. 3:20-21; Rom. 8:3; Gen. 3:15; Isa. 42:6, <strong>f.</strong> John 3:16; Rom. 10:6, 9; Rev. 22:17, <strong>g.</strong> Acts 13:48; Ezek. 36:26-27; John 6:37, 44-45; 1 Cor. 12:3</p></div>
 </details>
 
 <p><span id="wcf-7-4"></span>4. This covenant of grace is frequently set forth in Scripture by the name of a testament, in reference to the death of Jesus Christ the Testator, and to the everlasting inheritance, with all things belonging to it, <span class="v-const">therein bequeathed.</span><span class="v-modern">bequeathed in it.</span><sup class="proof-marker">h</sup></p>
@@ -374,7 +374,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-7-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>h.</strong> Heb. 9:15–17</p>
+<p><strong>h.</strong> Heb. 9:15-17</p>
 </div>
 </details>
 
@@ -383,7 +383,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-7-5-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>i.</strong> 2 Cor. 3:6–9, <strong>l.</strong> 1 Cor. 10:1–4; Heb. 11:13; John 8:56, <strong>m.</strong> Gal. 3:7–9, 14</p></div>
+<p><strong>i.</strong> 2 Cor. 3:6-9, <strong>l.</strong> 1 Cor. 10:1-4; Heb. 11:13; John 8:56, <strong>m.</strong> Gal. 3:7-9, 14</p></div>
 </details>
 
 <p><span id="wcf-7-6"></span>6. Under the gospel, when Christ, the substance,<sup class="proof-marker">n</sup> was exhibited, <span class="v-modern">1</span> the ordinances in which this covenant is dispensed are the preaching of the Word, and the administration of the sacraments of baptism and the Lord's Supper: which, though fewer in number, and administered with more simplicity, and less outward glory, yet, in them, it is held forth in more fullness, evidence and spiritual efficacy,<sup class="proof-marker">p</sup> to all nations, both Jews and Gentiles;<sup class="proof-marker">q</sup> and is called the new testament.<sup class="proof-marker">r</sup> There are not therefore two covenants of grace, differing in substance, but one and the same, under various dispensations.<sup class="proof-marker">s</sup></p>
@@ -391,7 +391,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-7-6-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>n.</strong> Col. 2:17, <strong>o.</strong> 1 Cor. 1:21; Matt. 28:19–20; 1 Cor. 11:23–25, <strong>p.</strong> Heb. 12:22–24; 2 Cor. 3:9–11; Jer. 31:33–34, <strong>q.</strong> Luke 2:32; Acts 10:34; Eph. 2:15–19, <strong>r.</strong> Rom. 6:23, <strong>s.</strong> Eph. 4:18</p></div>
+<p><strong>n.</strong> Col. 2:17, <strong>o.</strong> 1 Cor. 1:21; Matt. 28:19-20; 1 Cor. 11:23-25, <strong>p.</strong> Heb. 12:22-24; 2 Cor. 3:9-11; Jer. 31:33-34, <strong>q.</strong> Luke 2:32; Acts 10:34; Eph. 2:15-19, <strong>r.</strong> Rom. 6:23, <strong>s.</strong> Eph. 4:18</p></div>
 </details>
 
 ## CHAPTER 8: Of Christ the Mediator
@@ -400,7 +400,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-8-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Matt. 26:37–38; Luke 22:44; Matt. 27:46, <strong>b.</strong> Matt. 26:67–68; Matt. 27:27–50, <strong>c.</strong> Mark 15:24, 37; Phil. 2:8, <strong>d.</strong> Matt. 27:60; Acts 2:24, 27; Acts 13:29, 37; Rom. 6:9, <strong>e.</strong> 1 Cor. 15:3–4, <strong>f.</strong> Luke 24:39; John 20:25, 27, <strong>g.</strong> Luke 24:50–51; 1 Pet. 3:22, <strong>h.</strong> Rom. 8:34; Heb. 7:25; Heb. 9:24, <strong>i.</strong> Acts 1:11; John 5:28–29; Rom. 14:10b; Acts 10:42; Matt. 13:40–42; 2 Pet. 2:4; Rom. 5:19; Heb. 9:14</p></div>
+<p><strong>a.</strong> Matt. 26:37-38; Luke 22:44; Matt. 27:46, <strong>b.</strong> Matt. 26:67-68; Matt. 27:27-50, <strong>c.</strong> Mark 15:24, 37; Phil. 2:8, <strong>d.</strong> Matt. 27:60; Acts 2:24, 27; Acts 13:29, 37; Rom. 6:9, <strong>e.</strong> 1 Cor. 15:3-4, <strong>f.</strong> Luke 24:39; John 20:25, 27, <strong>g.</strong> Luke 24:50-51; 1 Pet. 3:22, <strong>h.</strong> Rom. 8:34; Heb. 7:25; Heb. 9:24, <strong>i.</strong> Acts 1:11; John 5:28-29; Rom. 14:10b; Acts 10:42; Matt. 13:40-42; 2 Pet. 2:4; Rom. 5:19; Heb. 9:14</p></div>
 </details>
 
 <p><span id="wcf-8-2"></span>2. The Son of God, the second person in the Trinity, being very and eternal God, of one substance and equal with the Father, <span class="v-const">did,</span> when the fullness of time was come, <span class="v-const">take</span><span class="v-modern">took</span> upon <span class="v-const">him</span><span class="v-modern">himself</span> man's nature, with all <span class="v-const">the</span><span class="v-modern">its</span> essential <span class="v-const">properties,</span><span class="v-modern">properties</span> and common <span class="v-const">infirmities thereof,</span><span class="v-modern">infirmities,</span> yet without sin;<sup class="proof-marker">l</sup> being conceived by the power of the Holy <span class="v-const">Ghost,</span><span class="v-modern">Spirit,</span> in the womb of the virgin Mary, of her substance.<sup class="proof-marker">m</sup> So that two whole, perfect, and distinct natures, the Godhead and the manhood, were inseparably joined together in one person, without conversion, composition, or confusion.<sup class="proof-marker">n</sup> <span class="v-const">Which</span><span class="v-modern">This</span> person is very God, and very man, yet one Christ, the only Mediator between God and man.<sup class="proof-marker">o</sup></p>
@@ -408,7 +408,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-8-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Dan. 9:24; 2 Cor. 5:18; Col. 1:20; Eph. 1:11, 14; Heb. 9:12, 15; John 17:2, <strong>m.</strong> Gal. 4:4–5; Gen. 3:15; 1 Cor. 10:4; Rev. 13:8; Heb. 13:8; Rom. 3:25; Heb. 9:15, <strong>n.</strong> John 10:17–18; 1 Pet. 3:18; Heb. 1:3; Heb. 9:14, <strong>o.</strong> Acts 20:28; Luke 1:43; Rom. 9:5</p></div>
+<p><strong>l.</strong> Dan. 9:24; 2 Cor. 5:18; Col. 1:20; Eph. 1:11, 14; Heb. 9:12, 15; John 17:2, <strong>m.</strong> Gal. 4:4-5; Gen. 3:15; 1 Cor. 10:4; Rev. 13:8; Heb. 13:8; Rom. 3:25; Heb. 9:15, <strong>n.</strong> John 10:17-18; 1 Pet. 3:18; Heb. 1:3; Heb. 9:14, <strong>o.</strong> Acts 20:28; Luke 1:43; Rom. 9:5</p></div>
 </details>
 
 <p><span id="wcf-8-3"></span>3. The Lord Jesus, in his human nature thus united to the divine, was sanctified, and anointed with the Holy Spirit, above measure,<sup class="proof-marker">p</sup> having in him all the treasures of wisdom and knowledge;<sup class="proof-marker">q</sup> in whom it pleased the Father that all fullness should dwell;<sup class="proof-marker">r</sup> to the end that, being holy, harmless, undefiled, and full of grace and truth,<sup class="proof-marker">s</sup> he might be thoroughly furnished to execute the office of a mediator, and surety.<sup class="proof-marker">t</sup> <span class="v-const">Which</span><span class="v-modern">He did not take this</span> office <span class="v-const">he took not unto</span><span class="v-modern">to</span> himself, but was <span class="v-const">thereunto</span> called <span class="v-modern">to it</span> by his Father,<sup class="proof-marker">u</sup> who put all power and judgment into his hand, and gave him commandment to execute the same.<sup class="proof-marker">w</sup></p>
@@ -416,7 +416,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-8-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>p.</strong> John 6:37, 39; John 10:15–16, 27–28, <strong>q.</strong> 1 John 2:1; Rom. 8:34, <strong>r.</strong> John 15:15; Eph. 1:9; John 17:6, <strong>s.</strong> Heb. 7:26; John 1:14, <strong>t.</strong> Acts 10:38; Heb. 12:24; Heb. 7:22, <strong>u.</strong> Heb. 5:4–5, <strong>w.</strong> John 5:22, 27; Matt. 28:18; Acts 2:36</p></div>
+<p><strong>p.</strong> John 6:37, 39; John 10:15-16, 27-28, <strong>q.</strong> 1 John 2:1; Rom. 8:34, <strong>r.</strong> John 15:15; Eph. 1:9; John 17:6, <strong>s.</strong> Heb. 7:26; John 1:14, <strong>t.</strong> Acts 10:38; Heb. 12:24; Heb. 7:22, <strong>u.</strong> Heb. 5:4-5, <strong>w.</strong> John 5:22, 27; Matt. 28:18; Acts 2:36</p></div>
 </details>
 
 <p><span id="wcf-8-4"></span>4. <span class="v-const">This office the</span><span class="v-modern">The</span> Lord Jesus <span class="v-const">did</span><span class="v-modern">undertook this office</span> most willingly undertake;<sup class="proof-marker">x</sup> which that he might <span class="v-const">discharge,</span><span class="v-modern">discharge it,</span> he was made under the law, and <span class="v-const">did</span> perfectly <span class="v-const">fulfill</span><span class="v-modern">fulfilled</span> it;<sup class="proof-marker">z</sup> endured most grievous torments immediately in his soul,<sup class="proof-marker">a</sup> and most painful sufferings in his body;<sup class="proof-marker">b</sup> was crucified, and died,<sup class="proof-marker">c</sup> was buried, and remained under the power of death, yet saw no corruption.<sup class="proof-marker">d</sup> On the third day he arose from the dead, with the same body in which he suffered,<sup class="proof-marker">f</sup> with which also he ascended into heaven, and there <span class="v-const">sitteth</span><span class="v-modern">sits</span> at the right hand of his Father,<sup class="proof-marker">g</sup> making intercession,<sup class="proof-marker">h</sup> and shall return, to judge men and angels, at the end of the world.<sup class="proof-marker">i</sup></p>
@@ -424,7 +424,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-8-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Matt. 26:37–38; Luke 22:44; Matt. 27:46, <strong>b.</strong> Matt. 26:67–68; Matt. 27:27–50, <strong>c.</strong> Mark 15:24, 37; Phil. 2:8, <strong>d.</strong> Matt. 27:60; Acts 2:24, 27; Acts 13:29, 37; Rom. 6:9, <strong>e.</strong> 1 Cor. 15:3–4, <strong>f.</strong> Luke 24:39; John 20:25, 27, <strong>g.</strong> Luke 24:50–51; 1 Pet. 3:22, <strong>h.</strong> Rom. 8:34; Heb. 7:25; Heb. 9:24, <strong>i.</strong> Acts 1:11; John 5:28–29; Rom. 14:10b; Acts 10:42; Matt. 13:40–42; 2 Pet. 2:4; Rom. 5:19; Heb. 9:14, <strong>x.</strong> Ps. 40:7–8; Heb. 10:5–10; John 4:34; John 10:18, <strong>z.</strong> Matt. 3:15; Matt. 5:17; Heb. 5:8–9</p></div>
+<p><strong>a.</strong> Matt. 26:37-38; Luke 22:44; Matt. 27:46, <strong>b.</strong> Matt. 26:67-68; Matt. 27:27-50, <strong>c.</strong> Mark 15:24, 37; Phil. 2:8, <strong>d.</strong> Matt. 27:60; Acts 2:24, 27; Acts 13:29, 37; Rom. 6:9, <strong>e.</strong> 1 Cor. 15:3-4, <strong>f.</strong> Luke 24:39; John 20:25, 27, <strong>g.</strong> Luke 24:50-51; 1 Pet. 3:22, <strong>h.</strong> Rom. 8:34; Heb. 7:25; Heb. 9:24, <strong>i.</strong> Acts 1:11; John 5:28-29; Rom. 14:10b; Acts 10:42; Matt. 13:40-42; 2 Pet. 2:4; Rom. 5:19; Heb. 9:14, <strong>x.</strong> Ps. 40:7-8; Heb. 10:5-10; John 4:34; John 10:18, <strong>z.</strong> Matt. 3:15; Matt. 5:17; Heb. 5:8-9</p></div>
 </details>
 
 <p><span id="wcf-8-5"></span>5. The Lord Jesus, by his perfect obedience, and sacrifice of himself, which he, through the eternal Spirit, once offered up <span class="v-const">unto</span><span class="v-modern">to</span> God, <span class="v-const">hath</span><span class="v-modern">has</span> fully satisfied the justice of his Father; and purchased, not only reconciliation, but an everlasting inheritance in the kingdom of heaven, for all those whom the Father hath given <span class="v-const">unto</span><span class="v-modern">to</span> him.<sup class="proof-marker">l</sup></p>
@@ -441,7 +441,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-8-6-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>m.</strong> Gal. 4:4–5; Gen. 3:15; 1 Cor. 10:4; Rev. 13:8; Heb. 13:8; Rom. 3:25; Heb. 9:15</p>
+<p><strong>m.</strong> Gal. 4:4-5; Gen. 3:15; 1 Cor. 10:4; Rev. 13:8; Heb. 13:8; Rom. 3:25; Heb. 9:15</p>
 </div>
 </details>
 
@@ -450,7 +450,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-8-7-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>n.</strong> John 10:17–18; 1 Pet. 3:18; Heb. 1:3; Heb. 9:14, <strong>o.</strong> Acts 20:28; Luke 1:43; Rom. 9:5</p></div>
+<p><strong>n.</strong> John 10:17-18; 1 Pet. 3:18; Heb. 1:3; Heb. 9:14, <strong>o.</strong> Acts 20:28; Luke 1:43; Rom. 9:5</p></div>
 </details>
 
 <p><span id="wcf-8-8"></span>8. To all those for whom Christ <span class="v-const">hath</span><span class="v-modern">has</span> purchased redemption, he <span class="v-const">doth</span> certainly and effectually <span class="v-const">apply</span><span class="v-modern">applies</span> and <span class="v-const">communicate</span><span class="v-modern">communicates</span> the same;<sup class="proof-marker">p</sup> making intercession for them,<sup class="proof-marker">q</sup> and revealing <span class="v-const">unto</span><span class="v-modern">to</span> them, in and by the Word, the mysteries of salvation;<sup class="proof-marker">r</sup> effectually persuading them by his Spirit to believe and obey, and governing their hearts by his Word and Spirit;<sup class="proof-marker">s</sup> overcoming all their enemies by his almighty power and wisdom, in such manner, and ways, as are most consonant to his wonderful and unsearchable dispensation.<sup class="proof-marker">t</sup></p>
@@ -458,7 +458,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-8-8-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>p.</strong> John 6:37, 39; John 10:15–16, 27–28, <strong>q.</strong> 1 John 2:1; Rom. 8:34, <strong>r.</strong> John 15:15; Eph. 1:9; John 17:6, <strong>s.</strong> Heb. 7:26; John 1:14, <strong>t.</strong> Acts 10:38; Heb. 12:24; Heb. 7:22</p></div>
+<p><strong>p.</strong> John 6:37, 39; John 10:15-16, 27-28, <strong>q.</strong> 1 John 2:1; Rom. 8:34, <strong>r.</strong> John 15:15; Eph. 1:9; John 17:6, <strong>s.</strong> Heb. 7:26; John 1:14, <strong>t.</strong> Acts 10:38; Heb. 12:24; Heb. 7:22</p></div>
 </details>
 
 ## CHAPTER 9: Of Free Will
@@ -467,7 +467,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-9-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Deut. 30:19; Isa. 7:11–12; Matt. 17:12; John 5:40</p>
+<p><strong>a.</strong> Deut. 30:19; Isa. 7:11-12; Matt. 17:12; John 5:40</p>
 </div>
 </details>
 
@@ -476,7 +476,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-9-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>b.</strong> Gen. 1:26, 31; Col. 3:10, <strong>c.</strong> Gen. 2:16–17; Gen. 3:6, 17</p></div>
+<p><strong>b.</strong> Gen. 1:26, 31; Col. 3:10, <strong>c.</strong> Gen. 2:16-17; Gen. 3:6, 17</p></div>
 </details>
 
 <p><span id="wcf-9-3"></span>3. Man, by his fall into a state of sin, <span class="v-const">hath</span><span class="v-modern">has</span> wholly lost all ability of will to any spiritual good accompanying salvation:<sup class="proof-marker">d</sup> so <span class="v-const">as,</span><span class="v-modern">that,</span> a natural man, being altogether averse from that good,<sup class="proof-marker">e</sup> and dead in sin,<sup class="proof-marker">f</sup> is not able, by his own strength, to convert himself, or to prepare himself <span class="v-const">thereunto.</span><span class="v-modern">for it.</span><sup class="proof-marker">g</sup></p>
@@ -484,7 +484,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-9-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>d.</strong> Rom. 8:7–8; John 6:44, 65; John 15:5; Rom. 5:5, <strong>e.</strong> Rom. 3:9–10, 12, 23, <strong>f.</strong> Eph. 2:1, 5; Col. 2:13, <strong>g.</strong> John 6:44, 65</p></div>
+<p><strong>d.</strong> Rom. 8:7-8; John 6:44, 65; John 15:5; Rom. 5:5, <strong>e.</strong> Rom. 3:9-10, 12, 23, <strong>f.</strong> Eph. 2:1, 5; Col. 2:13, <strong>g.</strong> John 6:44, 65</p></div>
 </details>
 
 <p><span id="wcf-9-4"></span>4. When God converts a sinner, and translates him into the state of grace, he <span class="v-const">freeth</span><span class="v-modern">frees</span> him from his natural bondage under sin;<sup class="proof-marker">h</sup> and, by his grace alone, enables him freely to will and to do that which is spiritually good;<sup class="proof-marker">i</sup> yet <span class="v-const">so, as</span><span class="v-modern">so</span> that by reason of his remaining corruption, he <span class="v-const">doth</span><span class="v-modern">does</span> not perfectly, nor only, will that which is good, but <span class="v-const">doth</span> also <span class="v-const">will</span><span class="v-modern">wills</span> that which is evil.</p>
@@ -492,7 +492,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-9-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>h.</strong> Col. 1:13; John 8:34, 36; Rom. 6:6–7, <strong>i.</strong> Phil. 2:13; Rom. 6:14, 17–19, 22; Gal. 5:17; Rom. 7:14–25</p></div>
+<p><strong>h.</strong> Col. 1:13; John 8:34, 36; Rom. 6:6-7, <strong>i.</strong> Phil. 2:13; Rom. 6:14, 17-19, 22; Gal. 5:17; Rom. 7:14-25</p></div>
 </details>
 
 <p><span id="wcf-9-5"></span>5. The will of man is made perfectly and immutably free to good alone, in the state of glory only.<sup class="proof-marker">l</sup></p>
@@ -510,7 +510,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-10-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Acts 13:48; Rom. 8:28, 30; Rom. 11:7; Eph. 1:5, 11; 2 Tim. 1:9–10, <strong>b.</strong> 2 Thess. 2:13–14; 2 Cor. 3:3, 6; 1 Cor. 2:12, <strong>c.</strong> 2 Tim. 1:9–10; 1 Pet. 2:9; Rom. 8:2; Eph. 2:1–10, <strong>d.</strong> Acts 26:18; 1 Cor. 2:10, 12; Eph. 1:17–18, <strong>e.</strong> Ezek. 36:26, <strong>f.</strong> Ezek. 11:19; Deut. 30:6; Ezek. 36:27; John 3:5; 1 Pet. 1:23, <strong>g.</strong> John 6:44–45; Acts 16:14, <strong>h.</strong> Ps. 110:3; John 6:37; Matt. 11:28; Rev. 22:17; Rom. 6:16–18; Eph. 2:8; Phil. 1:29</p></div>
+<p><strong>a.</strong> Acts 13:48; Rom. 8:28, 30; Rom. 11:7; Eph. 1:5, 11; 2 Tim. 1:9-10, <strong>b.</strong> 2 Thess. 2:13-14; 2 Cor. 3:3, 6; 1 Cor. 2:12, <strong>c.</strong> 2 Tim. 1:9-10; 1 Pet. 2:9; Rom. 8:2; Eph. 2:1-10, <strong>d.</strong> Acts 26:18; 1 Cor. 2:10, 12; Eph. 1:17-18, <strong>e.</strong> Ezek. 36:26, <strong>f.</strong> Ezek. 11:19; Deut. 30:6; Ezek. 36:27; John 3:5; 1 Pet. 1:23, <strong>g.</strong> John 6:44-45; Acts 16:14, <strong>h.</strong> Ps. 110:3; John 6:37; Matt. 11:28; Rev. 22:17; Rom. 6:16-18; Eph. 2:8; Phil. 1:29</p></div>
 </details>
 
 <p><span id="wcf-10-2"></span>2. This effectual call is of God's free and special grace alone, not from anything at all foreseen in man,<sup class="proof-marker">i</sup> who is altogether passive <span class="v-const">therein,</span><span class="v-modern">in it,</span> until, being <span class="v-const">quickened</span><span class="v-modern">made alive</span> and renewed by the Holy Spirit, he is <span class="v-const">thereby</span> enabled <span class="v-modern">in this way</span> to answer this call, and to embrace the grace offered and conveyed in it.<sup class="proof-marker">l</sup></p>
@@ -518,7 +518,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-10-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>i.</strong> 2 Tim. 1:9; Eph. 2:8–9; Rom. 9:11; 1 Cor. 2:14; Rom. 8:7–9, <strong>l.</strong> John 6:37; Ezek. 36:27; 1 John 5:1; 1 John 3:9</p></div>
+<p><strong>i.</strong> 2 Tim. 1:9; Eph. 2:8-9; Rom. 9:11; 1 Cor. 2:14; Rom. 8:7-9, <strong>l.</strong> John 6:37; Ezek. 36:27; 1 John 5:1; 1 John 3:9</p></div>
 </details>
 
 <p><span id="wcf-10-3"></span>3. Elect infants, dying in infancy, are regenerated, and saved by Christ, through the Spirit,<sup class="proof-marker">m</sup> who <span class="v-const">worketh</span><span class="v-modern">works</span> when, and where, and how he <span class="v-const">pleaseth:</span><span class="v-modern">pleases:</span><sup class="proof-marker">n</sup> so also are all other elect persons who are incapable of being outwardly called by the ministry of the Word.<sup class="proof-marker">o</sup></p>
@@ -526,7 +526,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-10-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>m.</strong> Gen. 17:7; Luke 18:15–16; Acts 2:39; John 3:3, 5; 1 John 5:12; Luke 1:15, <strong>n.</strong> John 3:8, <strong>o.</strong> John 16:7–8; 1 John 5:12; Acts 4:12</p></div>
+<p><strong>m.</strong> Gen. 17:7; Luke 18:15-16; Acts 2:39; John 3:3, 5; 1 John 5:12; Luke 1:15, <strong>n.</strong> John 3:8, <strong>o.</strong> John 16:7-8; 1 John 5:12; Acts 4:12</p></div>
 </details>
 
 <p><span id="wcf-10-4"></span>4. Others, not elected, although they may be called by the ministry of the Word,<sup class="proof-marker">p</sup> and may have some common operations of the Spirit,<sup class="proof-marker">q</sup> yet they never truly come <span class="v-const">unto</span><span class="v-modern">to</span> Christ, and therefore cannot be saved:<sup class="proof-marker">r</sup> much less can men, not professing the Christian religion, be saved in any other way whatsoever, <span class="v-const">be they never so diligent</span><span class="v-modern">despite their utmost diligence</span> to frame their lives according to the light of nature, and the laws of that religion they <span class="v-const">do</span> profess.<sup class="proof-marker">s</sup> And, to assert and maintain that they may, is very pernicious, and to be detested.<sup class="proof-marker">t</sup></p>
@@ -534,7 +534,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-10-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>p.</strong> Matt. 13:14–15; Acts 28:24; Acts 13:48; Matt. 22:14, <strong>q.</strong> Matt. 13:20–21; Matt. 7:22; Heb. 6:4–5, <strong>r.</strong> John 6:37, 64–66; John 8:44; John 13:18; John 17:12, <strong>s.</strong> Acts 4:12; 1 John 4:2–3</p></div>
+<p><strong>p.</strong> Matt. 13:14-15; Acts 28:24; Acts 13:48; Matt. 22:14, <strong>q.</strong> Matt. 13:20-21; Matt. 7:22; Heb. 6:4-5, <strong>r.</strong> John 6:37, 64-66; John 8:44; John 13:18; John 17:12, <strong>s.</strong> Acts 4:12; 1 John 4:2-3</p></div>
 </details>
 
 ## CHAPTER 11: Of Justification
@@ -543,7 +543,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-11-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Rom. 8:30; Rom. 3:24; Rom. 5:15–16, <strong>b.</strong> Rom. 4:5–8; 2 Cor. 5:19, 21; Rom. 3:22–28; Eph. 1:7; Jer. 23:6; 1 Cor. 1:30–31; Rom. 5:17–19, <strong>c.</strong> John 1:12; Acts 10:43; Acts 13:38–39</p></div>
+<p><strong>a.</strong> Rom. 8:30; Rom. 3:24; Rom. 5:15-16, <strong>b.</strong> Rom. 4:5-8; 2 Cor. 5:19, 21; Rom. 3:22-28; Eph. 1:7; Jer. 23:6; 1 Cor. 1:30-31; Rom. 5:17-19, <strong>c.</strong> John 1:12; Acts 10:43; Acts 13:38-39</p></div>
 </details>
 
 <p><span id="wcf-11-2"></span>2. Faith, thus receiving and resting on Christ and his righteousness, is the alone instrument of justification:<sup class="proof-marker">d</sup> yet <span class="v-const">is it</span><span class="v-modern">it is</span> not alone in the person justified, but is ever accompanied with all other saving graces, and is no dead faith, but <span class="v-const">worketh</span><span class="v-modern">works</span> by love.<sup class="proof-marker">e</sup></p>
@@ -559,7 +559,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-11-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>f.</strong> Mark 10:45; Rom. 5:8–10, 18–19; Gal. 3:13; 1 Tim. 2:5–6</p>
+<p><strong>f.</strong> Mark 10:45; Rom. 5:8-10, 18-19; Gal. 3:13; 1 Tim. 2:5-6</p>
 </div>
 </details>
 
@@ -568,7 +568,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-11-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Rom. 8:29–30; Gal. 3:8; 1 Pet. 1:2, 19–20, <strong>m.</strong> Gal. 4:4; 1 Tim. 2:6; Rom. 4:25, <strong>n.</strong> Eph. 2:3; Gal. 2:16; Col. 1:21–22</p></div>
+<p><strong>l.</strong> Rom. 8:29-30; Gal. 3:8; 1 Pet. 1:2, 19-20, <strong>m.</strong> Gal. 4:4; 1 Tim. 2:6; Rom. 4:25, <strong>n.</strong> Eph. 2:3; Gal. 2:16; Col. 1:21-22</p></div>
 </details>
 
 <p><span id="wcf-11-5"></span>5. God <span class="v-const">doth continue</span><span class="v-modern">continues</span> to forgive the sins of those that are justified;<sup class="proof-marker">o</sup> and, although they can never fall from the state of justification,<sup class="proof-marker">p</sup> yet they may, by their sins, fall under God's fatherly displeasure, and not have the light of his countenance restored <span class="v-const">unto</span><span class="v-modern">to</span> them, until they humble themselves, confess their sins, beg pardon, and renew their faith and repentance.<sup class="proof-marker">q</sup></p>
@@ -576,7 +576,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-11-5-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>o.</strong> Matt. 6:12; 1 John 1:7, 9; 1 John 2:1–2, <strong>p.</strong> Rom. 5:1–5, <strong>q.</strong> Ps. 89:30–33; Ps. 32:5; Matt. 26:75; Luke 1:20; 1 Cor. 11:30, 32</p></div>
+<p><strong>o.</strong> Matt. 6:12; 1 John 1:7, 9; 1 John 2:1-2, <strong>p.</strong> Rom. 5:1-5, <strong>q.</strong> Ps. 89:30-33; Ps. 32:5; Matt. 26:75; Luke 1:20; 1 Cor. 11:30, 32</p></div>
 </details>
 
 <p><span id="wcf-11-6"></span>6. The justification of believers under the old testament was, in all these respects, one and the same <span class="v-const">with</span><span class="v-modern">as</span> the justification of believers under the new testament.<sup class="proof-marker">r</sup></p>
@@ -594,7 +594,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-12-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Eph. 1:5; Gal. 4:4–5, <strong>b.</strong> Rom. 8:17; John 1:12, <strong>c.</strong> Num. 6:24–26, <strong>d.</strong> Rom. 8:15, <strong>e.</strong> Eph. 3:12; Heb. 4:16, <strong>f.</strong> Rom. 8:15; Gal. 4:6; Rom. 8:16, <strong>g.</strong> Ps. 103:13, <strong>h.</strong> Prov. 14:26, <strong>i.</strong> Matt. 6:30, 32; 1 Pet. 5:7; Heb. 12:6, <strong>l.</strong> Lam. 3:31–32; Ps. 89:30–35, <strong>m.</strong> Eph. 4:30, <strong>n.</strong> Heb. 6:12, <strong>o.</strong> 1 Pet. 1:3–4; Heb. 1:14</p></div>
+<p><strong>a.</strong> Eph. 1:5; Gal. 4:4-5, <strong>b.</strong> Rom. 8:17; John 1:12, <strong>c.</strong> Num. 6:24-26, <strong>d.</strong> Rom. 8:15, <strong>e.</strong> Eph. 3:12; Heb. 4:16, <strong>f.</strong> Rom. 8:15; Gal. 4:6; Rom. 8:16, <strong>g.</strong> Ps. 103:13, <strong>h.</strong> Prov. 14:26, <strong>i.</strong> Matt. 6:30, 32; 1 Pet. 5:7; Heb. 12:6, <strong>l.</strong> Lam. 3:31-32; Ps. 89:30-35, <strong>m.</strong> Eph. 4:30, <strong>n.</strong> Heb. 6:12, <strong>o.</strong> 1 Pet. 1:3-4; Heb. 1:14</p></div>
 </details>
 
 ## CHAPTER 13: Of Sanctification
@@ -603,7 +603,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-13-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> 1 Thess. 5:23–24; 2 Thess. 2:13–14; Ezek. 36:22–28; Acts 20:32; Phil. 3:10; Rom. 6:5–6, <strong>b.</strong> John 17:17, 19; Eph. 5:26; Rom. 8:13–14; 2 Thess. 2:13, <strong>c.</strong> Rom. 6:6, 14, <strong>d.</strong> Gal. 5:24; Rom. 8:13, <strong>e.</strong> Col. 1:10–11; Eph. 3:16–19, <strong>f.</strong> 2 Cor. 7:1; Col. 1:28; Col. 4:12; Heb. 12:14</p></div>
+<p><strong>a.</strong> 1 Thess. 5:23-24; 2 Thess. 2:13-14; Ezek. 36:22-28; Acts 20:32; Phil. 3:10; Rom. 6:5-6, <strong>b.</strong> John 17:17, 19; Eph. 5:26; Rom. 8:13-14; 2 Thess. 2:13, <strong>c.</strong> Rom. 6:6, 14, <strong>d.</strong> Gal. 5:24; Rom. 8:13, <strong>e.</strong> Col. 1:10-11; Eph. 3:16-19, <strong>f.</strong> 2 Cor. 7:1; Col. 1:28; Col. 4:12; Heb. 12:14</p></div>
 </details>
 
 <p><span id="wcf-13-2"></span>2. This sanctification is throughout, in the whole man;<sup class="proof-marker">g</sup> yet imperfect in this life, there abiding still some remnants of corruption in every part;<sup class="proof-marker">h</sup> <span class="v-const">whence ariseth</span><span class="v-modern">from which arises</span> a continual and irreconcilable war, the flesh lusting against the Spirit, and the Spirit against the flesh.<sup class="proof-marker">i</sup></p>
@@ -611,7 +611,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-13-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>g.</strong> 1 Thess. 5:23; Rom. 12:1–2, <strong>h.</strong> 1 John 1:8–10; Rom. 7:14–25</p></div>
+<p><strong>g.</strong> 1 Thess. 5:23; Rom. 12:1-2, <strong>h.</strong> 1 John 1:8-10; Rom. 7:14-25</p></div>
 </details>
 
 <p><span id="wcf-13-3"></span>3. In <span class="v-const">which</span><span class="v-modern">this</span> war, although the remaining corruption, for a time, may <span class="v-const">much</span><span class="v-modern">greatly</span> prevail; yet, through the continual supply of strength from the sanctifying Spirit of Christ, the regenerate part <span class="v-const">doth overcome;</span><span class="v-modern">overcomes;</span><sup class="proof-marker">l</sup> and so, the saints grow in grace,<sup class="proof-marker">m</sup> perfecting holiness in the fear of God.<sup class="proof-marker">n</sup></p>
@@ -629,7 +629,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-14-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Heb. 10:39, <strong>b.</strong> 1 Cor. 12:3; John 3:5; John 6:44–45, 65; Eph. 2:8; Phil. 1:29; 2 Pet. 1:1; 1 Pet. 1:2, <strong>c.</strong> Matt. 28:19–20; Rom. 10:14, 17; 1 Cor. 1:21, <strong>d.</strong> 1 Pet. 2:2; Acts 20:32; Rom. 1:16–17; Matt. 28:19; Acts 2:38; 1 Cor. 10:16; 1 Cor. 11:23–29</p></div>
+<p><strong>a.</strong> Heb. 10:39, <strong>b.</strong> 1 Cor. 12:3; John 3:5; John 6:44-45, 65; Eph. 2:8; Phil. 1:29; 2 Pet. 1:1; 1 Pet. 1:2, <strong>c.</strong> Matt. 28:19-20; Rom. 10:14, 17; 1 Cor. 1:21, <strong>d.</strong> 1 Pet. 2:2; Acts 20:32; Rom. 1:16-17; Matt. 28:19; Acts 2:38; 1 Cor. 10:16; 1 Cor. 11:23-29</p></div>
 </details>
 
 <p><span id="wcf-14-2"></span>2. By this faith, a Christian <span class="v-const">believeth</span><span class="v-modern">believes</span> to be true <span class="v-const">whatsoever</span><span class="v-modern">whatever</span> is revealed in the Word, for the authority of God himself speaking <span class="v-const">therein;</span><span class="v-modern">in it;</span><sup class="proof-marker">e</sup> and <span class="v-const">acteth</span><span class="v-modern">acts</span> differently upon that which each particular passage <span class="v-const">thereof containeth;</span><span class="v-modern">of it contains;</span> yielding obedience to the commands,<sup class="proof-marker">f</sup> trembling at the threatenings,<sup class="proof-marker">g</sup> and embracing the promises of God for this life, and that which is to come.<sup class="proof-marker">h</sup> But the principal acts of saving faith are accepting, receiving, and resting upon Christ alone for justification, sanctification, and eternal life, by virtue of the covenant of grace.<sup class="proof-marker">i</sup></p>
@@ -637,7 +637,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-14-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>e.</strong> 2 Pet. 1:20–21; John 4:42; 1 Thess. 2:13; 1 John 5:9–10; Acts 24:14, <strong>f.</strong> Ps. 119:10–11, 48, 97–98, 167–168; John 14:15, <strong>g.</strong> Ezra 9:4; Isa. 66:2; Heb. 4:1, <strong>h.</strong> Heb. 11:13; 1 Tim. 4:8, <strong>i.</strong> John 1:12; Acts 16:31; Gal. 2:20; Acts 15:11; 2 Tim. 1:9–10; Heb. 5:13–14; Rom. 14:1–2; Matt. 6:30; Rom. 4:19–20; Matt. 8:10</p></div>
+<p><strong>e.</strong> 2 Pet. 1:20-21; John 4:42; 1 Thess. 2:13; 1 John 5:9-10; Acts 24:14, <strong>f.</strong> Ps. 119:10-11, 48, 97-98, 167-168; John 14:15, <strong>g.</strong> Ezra 9:4; Isa. 66:2; Heb. 4:1, <strong>h.</strong> Heb. 11:13; 1 Tim. 4:8, <strong>i.</strong> John 1:12; Acts 16:31; Gal. 2:20; Acts 15:11; 2 Tim. 1:9-10; Heb. 5:13-14; Rom. 14:1-2; Matt. 6:30; Rom. 4:19-20; Matt. 8:10</p></div>
 </details>
 
 <p><span id="wcf-14-3"></span>3. This faith is different in degrees, weak or strong; <span class="v-const">ma</span><span class="v-modern">may</span>y be often and many ways assailed, and weakened, but gets the victory:<sup class="proof-marker">l</sup> growing up in many to the attainment of a full assurance, through Christ,<sup class="proof-marker">m</sup> who is both the author and finisher of our faith.<sup class="proof-marker">n</sup></p>
@@ -645,7 +645,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-14-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Luke 22:31–32; Eph. 6:16; 1 John 5:4–5, <strong>m.</strong> Heb. 6:11–12; Heb. 10:22; Col. 2:2, <strong>n.</strong> 2 Cor. 7:1</p></div>
+<p><strong>l.</strong> Luke 22:31-32; Eph. 6:16; 1 John 5:4-5, <strong>m.</strong> Heb. 6:11-12; Heb. 10:22; Col. 2:2, <strong>n.</strong> 2 Cor. 7:1</p></div>
 </details>
 
 ## CHAPTER 15: Of Repentance unto Life
@@ -662,7 +662,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-15-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>c.</strong> Ezek. 18:30–31; Ezek. 36:31; Isa. 30:22; Ps. 51:4; Jer. 31:18–19, <strong>d.</strong> Ps. 119:6, 59, 106; 2 Kings 23:25; Luke 1:6</p></div>
+<p><strong>c.</strong> Ezek. 18:30-31; Ezek. 36:31; Isa. 30:22; Ps. 51:4; Jer. 31:18-19, <strong>d.</strong> Ps. 119:6, 59, 106; 2 Kings 23:25; Luke 1:6</p></div>
 </details>
 
 <p><span id="wcf-15-3"></span>3. Although repentance <span class="v-const">be</span><span class="v-modern">is</span> not to be rested in, as any satisfaction for sin, or any cause of <span class="v-const">the pardon thereof,</span><span class="v-modern">its pardon,</span><sup class="proof-marker">e</sup> which is the act of God's free grace in Christ;<sup class="proof-marker">f</sup> yet it is of such necessity to all sinners, that none may expect pardon without it.<sup class="proof-marker">g</sup></p>
@@ -670,7 +670,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-15-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>e.</strong> Ezek. 36:31–32; Ezek. 16:61–63; Isa. 43:25, <strong>f.</strong> Hos. 14:2, 4; Rom. 3:24; Eph. 1:7, <strong>g.</strong> Luke 13:3, 5; Mark 1:4</p></div>
+<p><strong>e.</strong> Ezek. 36:31-32; Ezek. 16:61-63; Isa. 43:25, <strong>f.</strong> Hos. 14:2, 4; Rom. 3:24; Eph. 1:7, <strong>g.</strong> Luke 13:3, 5; Mark 1:4</p></div>
 </details>
 
 <p><span id="wcf-15-4"></span>4. As there is no sin so small, but it deserves damnation;<sup class="proof-marker">h</sup> so there is no sin so great, that it can bring damnation upon those who truly repent.<sup class="proof-marker">i</sup></p>
@@ -678,7 +678,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-15-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>h.</strong> Rom. 6:23; Gal. 3:10; Matt. 12:36, <strong>i.</strong> Isa. 55:7; Rom. 8:1; Isa. 1:16–18; Ps. 19:13; Matt. 26:75; Luke 19:8; 1 Tim. 1:13, 15</p></div>
+<p><strong>h.</strong> Rom. 6:23; Gal. 3:10; Matt. 12:36, <strong>i.</strong> Isa. 55:7; Rom. 8:1; Isa. 1:16-18; Ps. 19:13; Matt. 26:75; Luke 19:8; 1 Tim. 1:13, 15</p></div>
 </details>
 
 <p><span id="wcf-15-5"></span>5. Men ought not to content themselves with a general repentance, but it is every man's duty to endeavor to repent of his particular sins, particularly.</p>
@@ -695,7 +695,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-15-6-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Ps. 32:5–6; Ps. 51:1–14, <strong>n.</strong> Heb. 12:2</p></div>
+<p><strong>l.</strong> Ps. 32:5-6; Ps. 51:1-14, <strong>n.</strong> Heb. 12:2</p></div>
 </details>
 
 ## CHAPTER 16: Of Good Works
@@ -712,7 +712,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-16-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>d.</strong> Ps. 116:12–14; Col. 3:15–17; 1 Pet. 2:9, <strong>e.</strong> 1 John 2:3, 5; 2 Pet. 1:5–10, <strong>f.</strong> 2 Cor. 9:2; Matt. 5:16; 1 Tim. 4:12, <strong>g.</strong> 1 Tim. 6:1, <strong>h.</strong> 1 Pet. 2:15, <strong>i.</strong> 1 Pet. 2:12; Phil. 1:11; John 15:8; Eph. 2:10, <strong>l.</strong> Rom. 6:22</p></div>
+<p><strong>d.</strong> Ps. 116:12-14; Col. 3:15-17; 1 Pet. 2:9, <strong>e.</strong> 1 John 2:3, 5; 2 Pet. 1:5-10, <strong>f.</strong> 2 Cor. 9:2; Matt. 5:16; 1 Tim. 4:12, <strong>g.</strong> 1 Tim. 6:1, <strong>h.</strong> 1 Pet. 2:15, <strong>i.</strong> 1 Pet. 2:12; Phil. 1:11; John 15:8; Eph. 2:10, <strong>l.</strong> Rom. 6:22</p></div>
 </details>
 
 <p><span id="wcf-16-3"></span>3. Their ability to do good works is not at all of themselves, but wholly from the Spirit of Christ.<sup class="proof-marker">m</sup> And that they may be <span class="v-const">enabled thereunto,</span><span class="v-modern">so enabled,</span> beside the graces they have already received, there is required an actual influence of the same Holy Spirit, to work in them to will, and to do, of his good pleasure:<sup class="proof-marker">n</sup> yet <span class="v-const">are they</span><span class="v-modern">they are</span> not <span class="v-const">hereupon</span><span class="v-modern">therefore</span> to grow negligent, as if they were not bound to perform any duty unless <span class="v-const">upon</span><span class="v-modern">by</span> a special motion of the Spirit; but they ought to be diligent in stirring up the grace of God that is in them.<sup class="proof-marker">o</sup></p>
@@ -720,7 +720,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-16-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>m.</strong> John 15:4–6; Rom. 8:4–14, <strong>n.</strong> Phil. 2:13; Phil. 4:13; 2 Cor. 3:5; Eph. 3:16, <strong>o.</strong> Phil. 2:12; Heb. 6:11–12; 2 Pet. 1:3, 5, 10–11; Isa. 64:7; 2 Tim. 1:6; Acts 26:6–7</p></div>
+<p><strong>m.</strong> John 15:4-6; Rom. 8:4-14, <strong>n.</strong> Phil. 2:13; Phil. 4:13; 2 Cor. 3:5; Eph. 3:16, <strong>o.</strong> Phil. 2:12; Heb. 6:11-12; 2 Pet. 1:3, 5, 10-11; Isa. 64:7; 2 Tim. 1:6; Acts 26:6-7</p></div>
 </details>
 
 <p><span id="wcf-16-4"></span>4. <span class="v-const">They</span><span class="v-modern">Those</span> who, in their obedience, attain to the greatest height <span class="v-const">which</span><span class="v-modern">that</span> is possible in this life, are so far from being able to supererogate, and to do more than God requires, <span class="v-const">as</span> that they fall short of much <span class="v-const">which</span><span class="v-modern">that</span> in duty they are bound to do.<sup class="proof-marker">p</sup></p>
@@ -728,7 +728,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-16-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>p.</strong> Luke 17:10; Neh. 13:22; Rom. 8:21–25; Gal. 5:17</p>
+<p><strong>p.</strong> Luke 17:10; Neh. 13:22; Rom. 8:21-25; Gal. 5:17</p>
 </div>
 </details>
 
@@ -737,7 +737,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-16-5-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>q.</strong> Rom. 3:20; Rom. 4:2, 4, 6; Eph. 2:8–9; Rom. 8:18, 22–24; Ps. 16:2; Job 22:2–3; Job 35:7–8, <strong>r.</strong> Luke 17:10, <strong>s.</strong> Rom. 8:13–14; Gal. 5:22–23, <strong>t.</strong> Isa. 64:6; Gal. 5:17; Rom. 7:15, 18; Ps. 143:2; Ps. 130:3</p></div>
+<p><strong>q.</strong> Rom. 3:20; Rom. 4:2, 4, 6; Eph. 2:8-9; Rom. 8:18, 22-24; Ps. 16:2; Job 22:2-3; Job 35:7-8, <strong>r.</strong> Luke 17:10, <strong>s.</strong> Rom. 8:13-14; Gal. 5:22-23, <strong>t.</strong> Isa. 64:6; Gal. 5:17; Rom. 7:15, 18; Ps. 143:2; Ps. 130:3</p></div>
 </details>
 
 <p><span id="wcf-16-6"></span>6. <span class="v-const">Notwithstanding,</span><span class="v-modern">Nevertheless,</span> the persons of believers being accepted through Christ, their good works also are accepted in him;<sup class="proof-marker">u</sup> not as though they were in this life wholly unblamable and unreprovable in God's sight; but that he, looking upon them in his Son, is pleased to accept and reward that which is sincere, although accompanied with many weaknesses and imperfections.<sup class="proof-marker">x</sup></p>
@@ -745,7 +745,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-16-6-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>u.</strong> Eph. 1:6; 1 Pet. 2:5; Gen. 4:4; Heb. 11:4, <strong>w.</strong> Job 9:20; Ps. 143:2; 1 John 1:8, <strong>x.</strong> Heb. 13:20–21; 2 Cor. 8:12; Heb. 6:10</p></div>
+<p><strong>u.</strong> Eph. 1:6; 1 Pet. 2:5; Gen. 4:4; Heb. 11:4, <strong>w.</strong> Job 9:20; Ps. 143:2; 1 John 1:8, <strong>x.</strong> Heb. 13:20-21; 2 Cor. 8:12; Heb. 6:10</p></div>
 </details>
 
 <p><span id="wcf-16-7"></span>7. Works done by unregenerate men, although for the matter of them they may be things <span class="v-const">which</span><span class="v-modern">that</span> God commands; and of good use both to themselves and others:<sup class="proof-marker">y</sup> yet, because they proceed not from <span class="v-const">an</span><span class="v-modern">a</span> heart purified by faith;<sup class="proof-marker">z</sup> nor are done in a right manner, according to the Word;<sup class="proof-marker">a</sup> nor to a right end, the glory of God,<sup class="proof-marker">b</sup> they are therefore sinful, and cannot please God, or make a man <span class="v-const">meet</span><span class="v-modern">fit</span> to receive grace from God:<sup class="proof-marker">c</sup> and yet, their neglect of them is more sinful and displeasing <span class="v-const">unto</span><span class="v-modern">to</span> God.<sup class="proof-marker">d</sup></p>
@@ -753,7 +753,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-16-7-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> 1 Cor. 13:3; Isa. 1:12, <strong>b.</strong> Matt. 6:2, 5, 16, <strong>d.</strong> Ps. 116:12–14; Col. 3:15–17; 1 Pet. 2:9, <strong>y.</strong> 2 Kings 10:30–31; 1 Kings 21:27, 29; Luke 6:32–34; Luke 18:2–7; Rom. 13:4, <strong>z.</strong> Heb. 11:4, 6; Gen. 4:3–5</p></div>
+<p><strong>a.</strong> 1 Cor. 13:3; Isa. 1:12, <strong>b.</strong> Matt. 6:2, 5, 16, <strong>d.</strong> Ps. 116:12-14; Col. 3:15-17; 1 Pet. 2:9, <strong>y.</strong> 2 Kings 10:30-31; 1 Kings 21:27, 29; Luke 6:32-34; Luke 18:2-7; Rom. 13:4, <strong>z.</strong> Heb. 11:4, 6; Gen. 4:3-5</p></div>
 </details>
 
 ## CHAPTER 17: Of the Perseverance of the Saints
@@ -762,7 +762,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-17-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Phil. 1:6; 2 Pet. 1:10; Rom. 8:28–30; John 10:28–29; 1 John 3:9; 1 John 5:18; 1 Pet. 1:5, 9</p>
+<p><strong>a.</strong> Phil. 1:6; 2 Pet. 1:10; Rom. 8:28-30; John 10:28-29; 1 John 3:9; 1 John 5:18; 1 Pet. 1:5, 9</p>
 </div>
 </details>
 
@@ -771,7 +771,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-17-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>b.</strong> Ps. 89:3–4, 28–33; 2 Tim. 2:18–19; Jer. 31:3, <strong>c.</strong> Heb. 10:10, 14, <strong>d.</strong> John 14:16–17; 1 John 2:27; 1 John 3:9, <strong>e.</strong> Jer. 32:40; Ps. 89:34–37, <strong>f.</strong> John 6:38–40; John 10:28; 2 Thess. 3:3; 1 John 2:19</p></div>
+<p><strong>b.</strong> Ps. 89:3-4, 28-33; 2 Tim. 2:18-19; Jer. 31:3, <strong>c.</strong> Heb. 10:10, 14, <strong>d.</strong> John 14:16-17; 1 John 2:27; 1 John 3:9, <strong>e.</strong> Jer. 32:40; Ps. 89:34-37, <strong>f.</strong> John 6:38-40; John 10:28; 2 Thess. 3:3; 1 John 2:19</p></div>
 </details>
 
 <p><span id="wcf-17-3"></span>3. Nevertheless, they may, through the temptations of Satan and of the world, the <span class="v-const">prevalency</span><span class="v-modern">prevalence</span> of corruption remaining in them, and the neglect of the means of their preservation, fall into grievous sins;<sup class="proof-marker">g</sup> and, for a time, continue therein:<sup class="proof-marker">h</sup> whereby they incur God's displeasure,<sup class="proof-marker">i</sup> and grieve his Holy Spirit, come to be deprived of some measure of their graces and comforts,<sup class="proof-marker">l</sup> have their hearts hardened,<sup class="proof-marker">m</sup> and their consciences wounded;<sup class="proof-marker">n</sup> hurt and scandalize others,<sup class="proof-marker">o</sup> and bring temporal judgments upon themselves.<sup class="proof-marker">p</sup></p>
@@ -779,7 +779,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-17-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>g.</strong> Jonah 1:3, 10; Ps. 51:14; Matt. 26:70, 72, 74, <strong>h.</strong> 2 Sam. 12:9, 13; Gal. 2:11–14, <strong>i.</strong> Num. 20:12; 2 Sam. 11:27; Isa. 64:7, 9; Eph. 4:30, <strong>l.</strong> Ps. 51:8, 10, 12; Rev. 2:4; Matt. 26:75, <strong>m.</strong> Isa. 63:17, <strong>n.</strong> Ps. 32:3–4; Ps. 51:8, <strong>o.</strong> Gen. 12:10–20; 2 Sam. 12:14; Gal. 2:13, <strong>p.</strong> Ps. 89:31–32; 1 Cor. 11:32</p></div>
+<p><strong>g.</strong> Jonah 1:3, 10; Ps. 51:14; Matt. 26:70, 72, 74, <strong>h.</strong> 2 Sam. 12:9, 13; Gal. 2:11-14, <strong>i.</strong> Num. 20:12; 2 Sam. 11:27; Isa. 64:7, 9; Eph. 4:30, <strong>l.</strong> Ps. 51:8, 10, 12; Rev. 2:4; Matt. 26:75, <strong>m.</strong> Isa. 63:17, <strong>n.</strong> Ps. 32:3-4; Ps. 51:8, <strong>o.</strong> Gen. 12:10-20; 2 Sam. 12:14; Gal. 2:13, <strong>p.</strong> Ps. 89:31-32; 1 Cor. 11:32</p></div>
 </details>
 
 ## CHAPTER 18: Of the Assurance of Grace and Salvation
@@ -788,7 +788,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-18-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>c.</strong> 1 John 5:13; 1 John 2:3; 1 John 3:14, 18–19, 21, 24, <strong>d.</strong> Rom. 5:2, 5</p></div>
+<p><strong>c.</strong> 1 John 5:13; 1 John 2:3; 1 John 3:14, 18-19, 21, 24, <strong>d.</strong> Rom. 5:2, 5</p></div>
 </details>
 
 <p><span id="wcf-18-2"></span>2. This certainty is not a bare conjectural and probable persuasion grounded upon a fallible hope;<sup class="proof-marker">e</sup> but an infallible assurance of faith founded upon the divine truth of the promises of salvation,<sup class="proof-marker">f</sup> the inward evidence of those graces <span class="v-const">unto</span><span class="v-modern">to</span> which these promises are made,<sup class="proof-marker">g</sup> the testimony of the Spirit of adoption witnessing with our spirits that we are the children of God,<sup class="proof-marker">h</sup> which Spirit is the <span class="v-const">earnest</span><span class="v-modern">guarantee</span> of our inheritance, <span class="v-const">whereby</span><span class="v-modern">by which</span> we are sealed to the day of redemption.<sup class="proof-marker">i</sup></p>
@@ -796,7 +796,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-18-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>e.</strong> Heb. 6:11, 19, <strong>f.</strong> Heb. 6:17–18, <strong>g.</strong> 2 Pet. 1:4–11; 1 John 2:3; 1 John 3:14; 2 Cor. 1:12, <strong>h.</strong> Rom. 8:15–16, <strong>i.</strong> Eph. 1:13–14; Eph. 4:30; 2 Cor. 1:21–22; 1 John 5:13</p></div>
+<p><strong>e.</strong> Heb. 6:11, 19, <strong>f.</strong> Heb. 6:17-18, <strong>g.</strong> 2 Pet. 1:4-11; 1 John 2:3; 1 John 3:14; 2 Cor. 1:12, <strong>h.</strong> Rom. 8:15-16, <strong>i.</strong> Eph. 1:13-14; Eph. 4:30; 2 Cor. 1:21-22; 1 John 5:13</p></div>
 </details>
 
 <p><span id="wcf-18-3"></span>3. This infallible assurance <span class="v-const">doth</span><span class="v-modern">does</span> not so belong to the essence of faith, but that a true believer may wait long, and conflict with many <span class="v-const">difficulties</span><span class="v-modern">difficulties,</span> before he <span class="v-const">be</span><span class="v-modern">becomes a</span> partaker of it: yet, being enabled by the Spirit to know the things <span class="v-const">which</span><span class="v-modern">that</span> are freely given him <span class="v-const">of</span><span class="v-modern">by</span> God, he <span class="v-const">may,</span><span class="v-modern">may attain to it</span> without extraordinary revelation, in the right use of ordinary <span class="v-const">means, attain thereunto.</span><span class="v-modern">means.</span><sup class="proof-marker">l</sup> And therefore it is the duty of everyone to give all diligence to make his calling and election sure,<sup class="proof-marker">m</sup> that <span class="v-const">thereby</span><span class="v-modern">in this way</span> his heart may be enlarged in peace and joy in the Holy <span class="v-const">Ghost,</span><span class="v-modern">Spirit,</span> in love and thankfulness to God, and in strength and cheerfulness in the duties of obedience, the proper fruits of this assurance;<sup class="proof-marker">n</sup> so far is it from inclining men to looseness.<sup class="proof-marker">o</sup></p>
@@ -804,7 +804,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-18-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> 1 Cor. 2:12; 1 John 4:13; Heb. 6:11–12; Eph. 3:17–18, <strong>m.</strong> 2 Pet. 1:10, <strong>n.</strong> Rom. 5:1–2, 5; Rom. 14:17; Rom. 15:13; Eph. 1:3–4; Ps. 4:6–7; Ps. 119:32, <strong>o.</strong> 1 John 2:1–2; Rom. 6:1–2; 2 Cor. 7:1; Rom. 8:1, 12</p></div>
+<p><strong>l.</strong> 1 Cor. 2:12; 1 John 4:13; Heb. 6:11-12; Eph. 3:17-18, <strong>m.</strong> 2 Pet. 1:10, <strong>n.</strong> Rom. 5:1-2, 5; Rom. 14:17; Rom. 15:13; Eph. 1:3-4; Ps. 4:6-7; Ps. 119:32, <strong>o.</strong> 1 John 2:1-2; Rom. 6:1-2; 2 Cor. 7:1; Rom. 8:1, 12</p></div>
 </details>
 
 <p><span id="wcf-18-4"></span>4. True believers may have the assurance of their salvation <span class="v-const">divers ways</span> shaken, diminished, and <span class="v-const">intermitted;</span><span class="v-modern">intermitted in various ways;</span> as, by negligence in preserving of it, by falling into some special sin <span class="v-const">which woundeth</span><span class="v-modern">that wounds</span> the conscience and <span class="v-const">grieveth</span><span class="v-modern">grieves</span> the Spirit; by some sudden or vehement temptation, by God's withdrawing the light of his countenance, and <span class="v-const">suffering</span><span class="v-modern">allowing</span> even <span class="v-const">such as</span><span class="v-modern">those who</span> fear him to walk in darkness and to have no light:<sup class="proof-marker">p</sup> yet <span class="v-const">are they</span><span class="v-modern">they are</span> never utterly destitute of that seed of God, and life of faith, that love of Christ and the <span class="v-const">brethren,</span><span class="v-modern">brothers,</span> that sincerity of heart, and conscience of duty, out of which, by <span class="v-const">the</span> operation of the Spirit, this assurance <span class="v-const">may,</span><span class="v-modern">may be revived</span> in due <span class="v-const">time, be revived;</span><span class="v-modern">time;</span><sup class="proof-marker">q</sup> and by the which, in the meantime, they are supported from utter despair.<sup class="proof-marker">r</sup></p>
@@ -812,7 +812,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-18-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>p.</strong> Ps. 51:8, 12, 14; Eph. 4:30–31; Ps. 77:1–10; Ps. 31:22; Matt. 26:69–72; Luke 22:31–34, <strong>q.</strong> 1 John 3:9; Luke 22:32; Ps. 51:8, 12; Ps. 73:15, <strong>r.</strong> Mic. 7:7–9</p></div>
+<p><strong>p.</strong> Ps. 51:8, 12, 14; Eph. 4:30-31; Ps. 77:1-10; Ps. 31:22; Matt. 26:69-72; Luke 22:31-34, <strong>q.</strong> 1 John 3:9; Luke 22:32; Ps. 51:8, 12; Ps. 73:15, <strong>r.</strong> Mic. 7:7-9</p></div>
 </details>
 
 ## CHAPTER 19: Of the Law of God
@@ -821,7 +821,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-19-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Gen. 1:26–27; Gen. 2:17; Eph. 4:24; Rom. 2:14–15; Rom. 10:5; Rom. 5:12, 19; Gal. 3:10, 12</p>
+<p><strong>a.</strong> Gen. 1:26-27; Gen. 2:17; Eph. 4:24; Rom. 2:14-15; Rom. 10:5; Rom. 5:12, 19; Gal. 3:10, 12</p>
 </div>
 </details>
 
@@ -830,7 +830,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-19-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>b.</strong> Rom. 3:19; Rom. 13:8–9; Deut. 5:32; Deut. 10:4, <strong>c.</strong> Matt. 22:37–40</p></div>
+<p><strong>b.</strong> Rom. 3:19; Rom. 13:8-9; Deut. 5:32; Deut. 10:4, <strong>c.</strong> Matt. 22:37-40</p></div>
 </details>
 
 <p><span id="wcf-19-3"></span>3. Beside this law, commonly called moral, God was pleased to give to the people of Israel, as a church under age, ceremonial laws, containing several typical ordinances, partly of worship, prefiguring Christ, his graces, actions, sufferings, and benefits;<sup class="proof-marker">d</sup> and partly, holding forth <span class="v-const">divers</span><span class="v-modern">various</span> instructions of moral duties.<sup class="proof-marker">e</sup> All <span class="v-const">which</span><span class="v-modern">of these</span> ceremonial laws are now abrogated, under the new testament.<sup class="proof-marker">f</sup></p>
@@ -838,7 +838,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-19-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>d.</strong> Heb. 10:1; Gal. 4:1–3; Col. 2:17; Heb. 9:1–28, <strong>e.</strong> Lev. 19:9–10, 19, 23, 27, <strong>f.</strong> Col. 2:14, 16–17; Dan. 9:27; Eph. 2:15–16; Heb. 9:10; Acts 10:9–16; Acts 11:2–10</p></div>
+<p><strong>d.</strong> Heb. 10:1; Gal. 4:1-3; Col. 2:17; Heb. 9:1-28, <strong>e.</strong> Lev. 19:9-10, 19, 23, 27, <strong>f.</strong> Col. 2:14, 16-17; Dan. 9:27; Eph. 2:15-16; Heb. 9:10; Acts 10:9-16; Acts 11:2-10</p></div>
 </details>
 
 <p><span id="wcf-19-4"></span>4. To them also, as a body politic, he gave <span class="v-const">sundry</span><span class="v-modern">various</span> judicial laws, which expired together with the State of that people; not obliging any other now, further than <span class="v-const">the</span><span class="v-modern">their</span> general equity <span class="v-const">thereof</span> may require.<sup class="proof-marker">g</sup></p>
@@ -846,7 +846,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-19-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>g.</strong> Gen. 49:10; 1 Pet. 2:13–14; 1 Cor. 9:8–10</p>
+<p><strong>g.</strong> Gen. 49:10; 1 Pet. 2:13-14; 1 Cor. 9:8-10</p>
 </div>
 </details>
 
@@ -855,7 +855,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-19-5-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>h.</strong> Rom. 13:8–10; Rom. 3:31; Rom. 7:25; 1 Cor. 9:21; Gal. 5:14; Eph. 6:2–3; 1 John 2:3–4, 7; Rom. 3:20; Rom. 7:7–8; 1 John 3:4; Rom. 6:15, <strong>i.</strong> Deut. 6:4–5; Rom. 3:19; Matt. 19:4–6; Gen. 17:1; Matt. 5:17–19; Rom. 3:31; 1 Cor. 9:21; Luke 16:17–18</p></div>
+<p><strong>h.</strong> Rom. 13:8-10; Rom. 3:31; Rom. 7:25; 1 Cor. 9:21; Gal. 5:14; Eph. 6:2-3; 1 John 2:3-4, 7; Rom. 3:20; Rom. 7:7-8; 1 John 3:4; Rom. 6:15, <strong>i.</strong> Deut. 6:4-5; Rom. 3:19; Matt. 19:4-6; Gen. 17:1; Matt. 5:17-19; Rom. 3:31; 1 Cor. 9:21; Luke 16:17-18</p></div>
 </details>
 
 <p><span id="wcf-19-6"></span>6. Although true believers <span class="v-const">be</span><span class="v-modern">are</span> not under the law, as a covenant of works, to be <span class="v-const">thereby</span> justified, or <span class="v-const">condemned;</span><span class="v-modern">condemned by it;</span><sup class="proof-marker">l</sup> yet <span class="v-const">is it</span><span class="v-modern">it is</span> of great use to them, as well as to others; in that, as a rule of life informing them of the will of God, and their duty, it directs and binds them to walk accordingly;<sup class="proof-marker">m</sup> <span class="v-const">discovering</span><span class="v-modern">exposing</span> also the sinful pollutions of their nature, hearts, and lives;<sup class="proof-marker">n</sup> <span class="v-const">so <span class="v-const">as,</span><span class="v-modern">Therefore,</span></span><span class="v-modern">that,</span> examining themselves <span class="v-const">thereby,</span><span class="v-modern">by it,</span> they may come to further conviction of, humiliation for, and hatred against sin,<sup class="proof-marker">o</sup> together with a clearer sight of the need they have of Christ, and the perfection of his obedience.<sup class="proof-marker">p</sup> It is likewise of use to the regenerate, to restrain their corruptions, in that it forbids sin:<sup class="proof-marker">q</sup> and the threatenings of it serve to show what even their sins deserve; and what afflictions, in this life, they may expect for them, although freed from the curse <span class="v-const">thereof</span><span class="v-modern">for them</span> threatened in the law.<sup class="proof-marker">r</sup> The promises of it, in like manner, show them God's approbation of obedience, and what blessings they may expect <span class="v-const">upon</span><span class="v-modern">for</span> the performance <span class="v-const">thereof:</span><span class="v-modern">of it:</span><sup class="proof-marker">s</sup> although not as due to them by the law as a covenant of works.<sup class="proof-marker">t</sup> So as, a man's doing good, and refraining from evil, because the law <span class="v-const">encourageth</span><span class="v-modern">encourages</span> to the one, and <span class="v-const">deterreth</span><span class="v-modern">deters</span> from the other, is no evidence of his being under the law; and, not under grace.<sup class="proof-marker">u</sup></p>
@@ -863,7 +863,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-19-6-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Rom. 6:14; Rom.7:4; Gal. 2:16; Gal. 3:13; Gal. 4:4–5, <strong>m.</strong> Rom. 7:12, 22, 25; Ps. 119:1–6; 1 Cor. 7:19; Gal. 5:14–23, <strong>n.</strong> Rom. 7:7, 13; Rom. 3:20, <strong>o.</strong> Rom. 7:9, 14, 24, <strong>p.</strong> Gal. 3:24; Rom. 7:24–25; Rom. 8:3–4, <strong>q.</strong> Ps. 119:101, 104, 128, <strong>r.</strong> Ezra 9:13–14; Ps. 89:30–34; Gal. 3:13, <strong>s.</strong> Deut. 5:33; Lev. 18:5; Matt. 19:17, <strong>t.</strong> Gal. 2:16; Luke 17:10, <strong>u.</strong> Rom. 6:12–15; 1 Pet. 3:8–12; Ps. 34:12–16</p></div>
+<p><strong>l.</strong> Rom. 6:14; Rom.7:4; Gal. 2:16; Gal. 3:13; Gal. 4:4-5, <strong>m.</strong> Rom. 7:12, 22, 25; Ps. 119:1-6; 1 Cor. 7:19; Gal. 5:14-23, <strong>n.</strong> Rom. 7:7, 13; Rom. 3:20, <strong>o.</strong> Rom. 7:9, 14, 24, <strong>p.</strong> Gal. 3:24; Rom. 7:24-25; Rom. 8:3-4, <strong>q.</strong> Ps. 119:101, 104, 128, <strong>r.</strong> Ezra 9:13-14; Ps. 89:30-34; Gal. 3:13, <strong>s.</strong> Deut. 5:33; Lev. 18:5; Matt. 19:17, <strong>t.</strong> Gal. 2:16; Luke 17:10, <strong>u.</strong> Rom. 6:12-15; 1 Pet. 3:8-12; Ps. 34:12-16</p></div>
 </details>
 
 <p><span id="wcf-19-7"></span>7. Neither are the <span class="v-const">forementioned</span><span class="v-modern">aforementioned</span> uses of the law contrary to the grace of the gospel, but <span class="v-const">do</span> sweetly comply with it;<sup class="proof-marker">w</sup> the Spirit of Christ subduing and enabling the will of man to do that freely, and cheerfully, which the will of God, revealed in the law, <span class="v-const">requireth</span><span class="v-modern">requires</span> to be done.<sup class="proof-marker">x</sup></p>
@@ -881,7 +881,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-20-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> 1 Thess. 1:10, <strong>b.</strong> Gal. 1:4; Col. 1:13; Acts 26:18; Rom. 6:14, <strong>c.</strong> Rom. 8:28; Ps. 119:71; 2 Cor. 4:15–18; 1 Cor. 15:54–57; Rom. 5:9; Rom. 8:1; 1 Thess. 1:10, <strong>d.</strong> Rom. 5:1–2, <strong>e.</strong> Rom. 8:14–15; Gal. 4:6; 1 John 4:18, <strong>f.</strong> Gal. 3:8–9, 14, <strong>g.</strong> Gal. 4:1–7; Gal. 5:1; Acts 15:10–11, <strong>h.</strong> Heb. 4:14–16; Heb. 10:19–22, <strong>i.</strong> John 7:38–39; Acts 2:17–18; 2 Cor. 3:8, 13, 17–18; Jer. 31:31–34; Rom. 14:4, 10; 1 Cor. 10:29</p></div>
+<p><strong>a.</strong> 1 Thess. 1:10, <strong>b.</strong> Gal. 1:4; Col. 1:13; Acts 26:18; Rom. 6:14, <strong>c.</strong> Rom. 8:28; Ps. 119:71; 2 Cor. 4:15-18; 1 Cor. 15:54-57; Rom. 5:9; Rom. 8:1; 1 Thess. 1:10, <strong>d.</strong> Rom. 5:1-2, <strong>e.</strong> Rom. 8:14-15; Gal. 4:6; 1 John 4:18, <strong>f.</strong> Gal. 3:8-9, 14, <strong>g.</strong> Gal. 4:1-7; Gal. 5:1; Acts 15:10-11, <strong>h.</strong> Heb. 4:14-16; Heb. 10:19-22, <strong>i.</strong> John 7:38-39; Acts 2:17-18; 2 Cor. 3:8, 13, 17-18; Jer. 31:31-34; Rom. 14:4, 10; 1 Cor. 10:29</p></div>
 </details>
 
 <p><span id="wcf-20-2"></span>2. God alone is Lord of the conscience, and <span class="v-const">hath</span><span class="v-modern">has</span> left it free from the doctrines and commandments of men, <span class="v-const">which</span><span class="v-modern">that</span> are, in anything, contrary to his Word; or beside it, if matters of faith, or worship.<sup class="proof-marker">l</sup> So that, to believe such doctrines, or to obey such commands, out of conscience, is to betray true liberty of conscience:<sup class="proof-marker">m</sup> and the requiring of an implicit faith, and an absolute and blind obedience, is to destroy liberty of conscience, and reason also.<sup class="proof-marker">n</sup></p>
@@ -889,7 +889,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-20-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Acts 4:19; Acts 5:29; 1 Cor. 7:22–23; Matt. 15:1–6; Matt. 23:8–10, <strong>m.</strong> Col. 2:20–23; Gal. 1:10; Gal. 2:4–5; Gal. 4:9–10; Gal. 5:1, <strong>n.</strong> Rom. 10:17; Isa. 8:20; Acts 17:11; John 4:22; Rev. 13:12, 16–17; Jer. 8:9; 1 Pet. 3:15</p></div>
+<p><strong>l.</strong> Acts 4:19; Acts 5:29; 1 Cor. 7:22-23; Matt. 15:1-6; Matt. 23:8-10, <strong>m.</strong> Col. 2:20-23; Gal. 1:10; Gal. 2:4-5; Gal. 4:9-10; Gal. 5:1, <strong>n.</strong> Rom. 10:17; Isa. 8:20; Acts 17:11; John 4:22; Rev. 13:12, 16-17; Jer. 8:9; 1 Pet. 3:15</p></div>
 </details>
 
 <p><span id="wcf-20-3"></span>3. <span class="v-const">They</span><span class="v-modern">Those</span> who, upon pretense of Christian liberty, <span class="v-const">do</span> practice any sin, or cherish any lust, <span class="v-const">do thereby</span><span class="v-modern">in this way</span> destroy the end of Christian liberty, which is, that being delivered out of the hands of our enemies, we might serve the Lord without fear, in holiness and righteousness before him, all the days of our life.<sup class="proof-marker">o</sup></p>
@@ -906,7 +906,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-20-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>p.</strong> 1 Pet. 2:13–14, 16; Rom. 13:1–8; Heb. 13:17; 1 Thess. 5:12–13, <strong>q.</strong> Rom. 1:32; 1 Cor. 5:1, 5, 11–13; 2 Thess. 3:6, 14; 1 Tim. 6:3–4; Rom. 16:17; Matt. 18:15–17; 1 Tim. 1:19–20; Rev. 2:2, 14–15, 20</p></div>
+<p><strong>p.</strong> 1 Pet. 2:13-14, 16; Rom. 13:1-8; Heb. 13:17; 1 Thess. 5:12-13, <strong>q.</strong> Rom. 1:32; 1 Cor. 5:1, 5, 11-13; 2 Thess. 3:6, 14; 1 Tim. 6:3-4; Rom. 16:17; Matt. 18:15-17; 1 Tim. 1:19-20; Rev. 2:2, 14-15, 20</p></div>
 </details>
 
 ## CHAPTER 21: Of Religious Worship, and the Sabbath Day
@@ -924,7 +924,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-21-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>c.</strong> John 4:21, <strong>d.</strong> Mal. 1:11; 1 Tim. 2:8, <strong>e.</strong> John 4:23–24</p></div>
+<p><strong>c.</strong> John 4:21, <strong>d.</strong> Mal. 1:11; 1 Tim. 2:8, <strong>e.</strong> John 4:23-24</p></div>
 </details>
 
 <p><span id="wcf-21-3"></span>3. Prayer, with thanksgiving, being one special part of religious worship,<sup class="proof-marker">f</sup> is <span class="v-const">by God</span> required of all <span class="v-const">men:</span><span class="v-modern">men by God:</span><sup class="proof-marker">g</sup> and, that it may be accepted, it is to be made in the name of the Son,<sup class="proof-marker">h</sup> by the help of his Spirit,<sup class="proof-marker">i</sup> according to his will, with understanding, reverence, humility, fervency, faith, love, and perseverance;<sup class="proof-marker">l</sup> and, if vocal, in a known tongue.<sup class="proof-marker">m</sup></p>
@@ -932,7 +932,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-21-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>f.</strong> Jer. 10:25; Deut. 6:6–7, <strong>g.</strong> Matt. 6:11; Job 1:5, <strong>h.</strong> Matt. 6:6, 16–18; Neh. 1:4–11; Dan. 9:3–4a, <strong>i.</strong> Isa. 56:6–7; Heb. 10:25; Ps. 100:4; Ps. 122:1; Ps. 84:1–12; Luke 4:16; Acts 13:42, 44, <strong>l.</strong> Gen. 2:2–3; 1 Cor. 16:1–2; Acts 20:7, <strong>m.</strong> Rev. 1:10</p></div>
+<p><strong>f.</strong> Jer. 10:25; Deut. 6:6-7, <strong>g.</strong> Matt. 6:11; Job 1:5, <strong>h.</strong> Matt. 6:6, 16-18; Neh. 1:4-11; Dan. 9:3-4a, <strong>i.</strong> Isa. 56:6-7; Heb. 10:25; Ps. 100:4; Ps. 122:1; Ps. 84:1-12; Luke 4:16; Acts 13:42, 44, <strong>l.</strong> Gen. 2:2-3; 1 Cor. 16:1-2; Acts 20:7, <strong>m.</strong> Rev. 1:10</p></div>
 </details>
 
 <p><span id="wcf-21-4"></span>4. Prayer is to be made for <span class="v-const">things lawful;</span><span class="v-modern">lawful things;</span><sup class="proof-marker">n</sup> and for all sorts of men living, or that shall <span class="v-const">live hereafter:</span><span class="v-modern">yet live:</span><sup class="proof-marker">o</sup> but not for the dead,<sup class="proof-marker">p</sup> nor for those of whom it may be known that they have sinned the sin <span class="v-const">unto</span><span class="v-modern">that leads to</span> death.<sup class="proof-marker">q</sup></p>
@@ -940,7 +940,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-21-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>n.</strong> Matt. 5:17–18, <strong>o.</strong> Isa. 58:13–14; Neh. 13:15–22, <strong>p.</strong> Isa. 58:13–14; Luke 4:16; Matt. 12:1–13; Mark 3:1–5, <strong>q.</strong> 1 John 5:16</p></div>
+<p><strong>n.</strong> Matt. 5:17-18, <strong>o.</strong> Isa. 58:13-14; Neh. 13:15-22, <strong>p.</strong> Isa. 58:13-14; Luke 4:16; Matt. 12:1-13; Mark 3:1-5, <strong>q.</strong> 1 John 5:16</p></div>
 </details>
 
 <p><span id="wcf-21-5"></span>5. The reading of the Scriptures with godly fear,<sup cl<span class="v-const">as</span><span class="v-modern">and</span>s="proof-marker">r</sup> the sound preaching and <span class="v-const">conscionable</span><span class="v-modern">conscientious</span> hearing of the Word, in obedience <span class="v-const">unto</span><span class="v-modern">to</span> God, with understanding, faith, and reverence,<sup class="proof-marker">t</sup> singing of psalms with grace in the heart;<sup class="proof-marker">u</sup> as also, the due administration and worthy receiving of the sacraments instituted by Christ, are all parts of the ordinary religious worship of God:<sup class="proof-marker">w</sup> beside religious oaths,<sup class="proof-marker">x</sup> vows,<sup class="proof-marker">y</sup> solemn fastings,<sup class="proof-marker">z</sup> and thanksgivings upon special occasions,<sup class="proof-marker">a</sup> which are, in their several times and seasons, to be used in <span class="v-const">an</span><span class="v-modern">a</span> holy and religious manner.<sup class="proof-marker">b</sup></p>
@@ -948,7 +948,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-21-5-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>b.</strong> Heb. 12:28, <strong>r.</strong> Luke 4:16–17; Acts 15:21; Col. 4:16; 1 Thess. 5:27; Rev. 1:3, <strong>t.</strong> Acts 10:33; Matt. 13:19; Heb. 4:2; Isa. 66:2, <strong>u.</strong> Col. 3:16; Eph. 5:19; 1 Cor. 14:15, <strong>w.</strong> Matt. 28:19; 1 Cor. 11:23–29; Acts 2:42, <strong>x.</strong> Deut. 6:13; Neh. 10:29; 2 Cor. 1:23, <strong>y.</strong> Ps. 116:14; Isa. 19:21, <strong>z.</strong> Joel 2:12; Est. 4:16; Matt. 9:15; Acts 14:23</p></div>
+<p><strong>b.</strong> Heb. 12:28, <strong>r.</strong> Luke 4:16-17; Acts 15:21; Col. 4:16; 1 Thess. 5:27; Rev. 1:3, <strong>t.</strong> Acts 10:33; Matt. 13:19; Heb. 4:2; Isa. 66:2, <strong>u.</strong> Col. 3:16; Eph. 5:19; 1 Cor. 14:15, <strong>w.</strong> Matt. 28:19; 1 Cor. 11:23-29; Acts 2:42, <strong>x.</strong> Deut. 6:13; Neh. 10:29; 2 Cor. 1:23, <strong>y.</strong> Ps. 116:14; Isa. 19:21, <strong>z.</strong> Joel 2:12; Est. 4:16; Matt. 9:15; Acts 14:23</p></div>
 </details>
 
 <p><span id="wcf-21-6"></span>6. Neither prayer, nor any other part of religious worship, is now, under the gospel, either tied <span class="v-const">unto,</span><span class="v-modern">to,</span> or made more acceptable by any place in which it is performed, or towards which it is directed:<sup class="proof-marker">c</sup> but God is to be worshiped everywhere,<sup class="proof-marker">d</sup> in spirit and truth;<sup class="proof-marker">e</sup> as, in private families daily, and in secret, each one by himself;<sup class="proof-marker">h</sup> so, more solemnly in the public assemblies, which are not carelessly or willfully to be neglected, or forsaken, when <span class="v-const">God,</span><span class="v-modern">God calls men to them</span> by his Word or <span class="v-const">providence, calleth thereunto.</span><span class="v-modern">providence.</span><sup class="proof-marker">i</sup></p>
@@ -956,7 +956,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-21-6-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>c.</strong> John 4:21, <strong>d.</strong> Mal. 1:11; 1 Tim. 2:8, <strong>e.</strong> John 4:23–24, <strong>g.</strong> Matt. 6:11; Job 1:5, <strong>h.</strong> Matt. 6:6, 16–18; Neh. 1:4–11; Dan. 9:3–4a, <strong>i.</strong> Isa. 56:6–7; Heb. 10:25; Ps. 100:4; Ps. 122:1; Ps. 84:1–12; Luke 4:16; Acts 13:42, 44</p></div>
+<p><strong>c.</strong> John 4:21, <strong>d.</strong> Mal. 1:11; 1 Tim. 2:8, <strong>e.</strong> John 4:23-24, <strong>g.</strong> Matt. 6:11; Job 1:5, <strong>h.</strong> Matt. 6:6, 16-18; Neh. 1:4-11; Dan. 9:3-4a, <strong>i.</strong> Isa. 56:6-7; Heb. 10:25; Ps. 100:4; Ps. 122:1; Ps. 84:1-12; Luke 4:16; Acts 13:42, 44</p></div>
 </details>
 
 <p><span id="wcf-21-7"></span>7. As it is the law of nature, that, in general, a due proportion of time <span class="v-modern">should</span> be set apart for the worship of God; so, in his Word, by a positive, moral, and perpetual commandment binding all men in all ages, he <span class="v-const">hath</span><span class="v-modern">has</span> particularly appointed one day in seven, for a Sabbath, to be kept holy <span class="v-const">unto</span><span class="v-modern">to</span> him: which, from the beginning of the world to the resurrection of Christ, was the last day of the week; and, from the resurrection of Christ, was changed into the first day of the week,<sup class="proof-marker">l</sup> which, in Scripture, is called the Lord's <span class="v-const">day,</span><span class="v-modern">Day,</span> and is to be continued to the end of the world, as the Christian Sabbath.<sup class="proof-marker">n</sup></p>
@@ -964,7 +964,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-21-7-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Gen. 2:2–3; 1 Cor. 16:1–2; Acts 20:7, <strong>m.</strong> Rev. 1:10, <strong>n.</strong> Matt. 5:17–18</p></div>
+<p><strong>l.</strong> Gen. 2:2-3; 1 Cor. 16:1-2; Acts 20:7, <strong>m.</strong> Rev. 1:10, <strong>n.</strong> Matt. 5:17-18</p></div>
 </details>
 
 <p><span id="wcf-21-8"></span>8. This Sabbath is then kept holy <span class="v-const">unto</span><span class="v-modern">to</span> the Lord, when men, after a due preparing of their hearts, and ordering of their common affairs beforehand, <span class="v-const">do</span> not only observe <span class="v-const">an</span><span class="v-modern">a</span> holy rest, all the day, from their own works, words, and thoughts about their worldly employments and recreations,<sup class="proof-marker">o</sup> but also are taken up, the whole time, in the public and private exercises of his worship, and in the duties of necessity and mercy.<sup class="proof-marker">p</sup></p>
@@ -972,7 +972,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-21-8-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>o.</strong> Isa. 58:13–14; Neh. 13:15–22, <strong>p.</strong> Isa. 58:13–14; Luke 4:16; Matt. 12:1–13; Mark 3:1–5</p></div>
+<p><strong>o.</strong> Isa. 58:13-14; Neh. 13:15-22, <strong>p.</strong> Isa. 58:13-14; Luke 4:16; Matt. 12:1-13; Mark 3:1-5</p></div>
 </details>
 
 ## CHAPTER 22: Of Lawful Oaths and Vows
@@ -981,7 +981,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-22-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Deut. 10:20; Isa. 45:23; Rom. 14:11; Phil. 2:10–11, <strong>b.</strong> Lev. 19:12; Rom. 1:9; 2 Cor. 1:23; 2 Cor. 11:31; Gal. 1:20; 2 Chron. 6:22–23</p></div>
+<p><strong>a.</strong> Deut. 10:20; Isa. 45:23; Rom. 14:11; Phil. 2:10-11, <strong>b.</strong> Lev. 19:12; Rom. 1:9; 2 Cor. 1:23; 2 Cor. 11:31; Gal. 1:20; 2 Chron. 6:22-23</p></div>
 </details>
 
 <p><span id="wcf-22-2"></span>2. The name of God <span class="v-const">only</span><span class="v-modern">alone</span> is that by which men ought to swear, and <span class="v-const">therein</span><span class="v-modern">in doing so</span> it is to be used with all holy fear and reverence.<sup class="proof-marker">c</sup> Therefore, to swear vainly, or rashly, by that glorious and dreadful Name; or, to swear at all by any other thing, is sinful, and to be abhorred.<sup class="proof-marker">d</sup> Yet, as in matters of weight and moment, an oath is warranted by the Word of God, under the new testament as well as under the old;<sup class="proof-marker">e</sup> so a lawful oath, being imposed by lawful authority, in such matters, ought to be taken.<sup class="proof-marker">f</sup></p>
@@ -989,7 +989,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-22-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>c.</strong> Deut. 6:13; Josh. 23:7, <strong>d.</strong> Jer. 5:7; Matt. 5:33–37, <strong>e.</strong> Heb. 6:16; 2 Cor. 1:23; Isa. 65:16, <strong>f.</strong> 1 Kings 8:31; Neh. 13:25; Ezra 10:5</p></div>
+<p><strong>c.</strong> Deut. 6:13; Josh. 23:7, <strong>d.</strong> Jer. 5:7; Matt. 5:33-37, <strong>e.</strong> Heb. 6:16; 2 Cor. 1:23; Isa. 65:16, <strong>f.</strong> 1 Kings 8:31; Neh. 13:25; Ezra 10:5</p></div>
 </details>
 
 <p><span id="wcf-22-3"></span>3. <span class="v-const">Whosoever taketh</span><span class="v-modern">Whoever takes</span> an oath ought duly to consider the weightiness of so solemn an act, and <span class="v-const">therein</span> to <span class="v-const">avouch</span><span class="v-modern">avow in it</span> nothing but what he is fully persuaded is the truth:<sup class="proof-marker">g</sup> neither may any man bind himself by oath to anything but what is good and just, and what he <span class="v-const">believeth so</span><span class="v-modern">believes</span> to <span class="v-const">be,</span><span class="v-modern">be so,</span> and what he is able and resolved to perform.<sup class="proof-marker">h</sup></p>
@@ -997,7 +997,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-22-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>g.</strong> Lev. 19:12; Jer. 4:2; Hos. 10:4, <strong>h.</strong> Gen. 24:2–9</p></div>
+<p><strong>g.</strong> Lev. 19:12; Jer. 4:2; Hos. 10:4, <strong>h.</strong> Gen. 24:2-9</p></div>
 </details>
 
 <p><span id="wcf-22-4"></span>4. An oath is to be taken in the plain and common <span class="v-const">sens</span><span class="v-modern">sense</span>e of the words, without equivocation, or mental reservation.<sup class="proof-marker">i</sup> It cannot oblige to sin; but in anything not sinful, being taken, it binds to performance, although to a man's own hurt. Nor is it to be violated, although made to heretics, or infidels.<sup class="proof-marker">l</sup></p>
@@ -1005,7 +1005,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-22-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>i.</strong> Jer. 4:2; Ps. 24:4; 1 Sam. 25:22, 32–34; Ps. 15:4, <strong>l.</strong> Ezek. 17:16–19; Josh. 9:18–19; 2 Sam. 21:1</p></div>
+<p><strong>i.</strong> Jer. 4:2; Ps. 24:4; 1 Sam. 25:22, 32-34; Ps. 15:4, <strong>l.</strong> Ezek. 17:16-19; Josh. 9:18-19; 2 Sam. 21:1</p></div>
 </details>
 
 <p><span id="wcf-22-5"></span>5. A vow is of the <span class="v-const"><span class="v-const"><span class="v-const">like</span><span class="v-modern">same</span></span><span class="v-modern">same</span></span><span class="v-modern">same</span> nature <span class="v-const">with</span><span class="v-modern">as</span> a promissory oath, and ought to be made with the like religious care, and to be performed with the like faithfulness.<sup class="proof-marker">m</sup></p>
@@ -1013,7 +1013,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-22-5-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>m.</strong> Num. 30:2; Isa. 19:21; Ps. 61:8; Ps. 66:13–14</p>
+<p><strong>m.</strong> Num. 30:2; Isa. 19:21; Ps. 61:8; Ps. 66:13-14</p>
 </div>
 </details>
 
@@ -1022,7 +1022,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-22-6-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>n.</strong> Ps. 50:14; Ps. 76:11; Ps. 116:14, <strong>o.</strong> Deut. 23:21–23; Gen. 28:20–22; 1 Sam. 1:11; Ps. 66:13–14; Ps. 132:2</p></div>
+<p><strong>n.</strong> Ps. 50:14; Ps. 76:11; Ps. 116:14, <strong>o.</strong> Deut. 23:21-23; Gen. 28:20-22; 1 Sam. 1:11; Ps. 66:13-14; Ps. 132:2</p></div>
 </details>
 
 <p><span id="wcf-22-7"></span>7. No man may vow to do anything forbidden in the Word of God, or what would hinder any duty <span class="v-const">therein commanded,</span><span class="v-modern">commanded in it,</span> or <span class="v-const">which</span><span class="v-modern">that</span> is not in his own power, and for the performance <span class="v-const">whereof</span><span class="v-modern">of which</span> he <span class="v-const">hath</span><span class="v-modern">has</span> no promise of ability from God.<sup class="proof-marker">p</sup> In <span class="v-const">which</span><span class="v-modern">these</span> respects, popish <span class="v-const">monastical</span><span class="v-modern">monastic</span> vows of perpetual single life, professed poverty, and regular obedience, are so far from being degrees of higher perfection, that they are superstitious and sinful snares, in which no Christian may entangle himself.<sup class="proof-marker">q</sup></p>
@@ -1030,7 +1030,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-22-7-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>p.</strong> Acts 23:12–14; Mark 6:26; Num. 30:5, 8, 12–13, <strong>q.</strong> Matt. 19:11–12; 1 Cor. 7:2, 9; Heb. 13:4; Eph. 4:28; 1 Thess. 4:11–12; 1 Cor. 7:23</p></div>
+<p><strong>p.</strong> Acts 23:12-14; Mark 6:26; Num. 30:5, 8, 12-13, <strong>q.</strong> Matt. 19:11-12; 1 Cor. 7:2, 9; Heb. 13:4; Eph. 4:28; 1 Thess. 4:11-12; 1 Cor. 7:23</p></div>
 </details>
 
 ## CHAPTER 23: Of the Civil Magistrate
@@ -1039,7 +1039,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-23-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Rom. 13:1–4; 1 Pet. 2:13–14</p>
+<p><strong>a.</strong> Rom. 13:1-4; 1 Pet. 2:13-14</p>
 </div>
 </details>
 
@@ -1048,7 +1048,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-23-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>b.</strong> Gen. 41:39–43; Neh. 12:26; Neh. 13:15–31; Dan. 2:48–49; Prov. 8:15–16, <strong>c.</strong> Ps. 2:10–12; 1 Tim. 2:2; Ps. 82:3–4; 2 Sam. 23:3; 1 Pet. 2:13, <strong>d.</strong> Luke 3:14; Rom. 13:4; Matt. 8:9–10; Acts 10:1–2</p></div>
+<p><strong>b.</strong> Gen. 41:39-43; Neh. 12:26; Neh. 13:15-31; Dan. 2:48-49; Prov. 8:15-16, <strong>c.</strong> Ps. 2:10-12; 1 Tim. 2:2; Ps. 82:3-4; 2 Sam. 23:3; 1 Pet. 2:13, <strong>d.</strong> Luke 3:14; Rom. 13:4; Matt. 8:9-10; Acts 10:1-2</p></div>
 </details>
 
 <p><span id="wcf-23-3"></span>3. Civil magistrates may not assume to themselves the administration of the Word and sacraments; or the power of the keys of the kingdom of heaven;<sup class="proof-marker">e</sup> or, in the least, interfere in matters of faith. Yet, as nursing fathers, it is the duty of civil magistrates to protect the church of our common Lord, without giving the preference to any denomination of Christians above the rest, in such a manner that all ecclesiastical persons whatever shall enjoy the full, free, and unquestioned liberty of discharging every part of their sacred functions, without violence or danger.<sup class="proof-marker">g</sup> And, as Jesus Christ <span class="v-const">hath</span><span class="v-modern">has</span> appointed a regular government and discipline in his church, no law of any commonwealth should interfere with, <span class="v-const">let,</span><span class="v-modern">obstruct,</span> or hinder, <span class="v-const">the</span><span class="v-modern">its</span> due <span class="v-const">exercise thereof,</span><span class="v-modern">exercise,</span> among the voluntary members of any denomination of Christians, according to their own profession and belief.<sup class="proof-marker">h</sup> It is the duty of civil magistrates to protect the person and good name of all their people, in such an effectual manner <span class="v-const">as</span> that no person be <span class="v-const">suffered,</span><span class="v-modern">permitted,</span> either upon pretense of religion or of infidelity, to offer any indignity, violence, abuse, or injury to any other person whatsoever: and to take order, that all religious and ecclesiastical assemblies be held without molestation or disturbance.<sup class="proof-marker">i</sup></p>
@@ -1056,7 +1056,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-23-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>e.</strong> 2 Chron. 26:18; Matt. 18:17; Matt. 16:19, <strong>f.</strong> John 18:36; Acts 5:29; Eph. 4:11–12, <strong>g.</strong> Isa. 49:23; Rom. 13:1–6, <strong>h.</strong> Ps. 105:15, <strong>i.</strong> Rom. 13:4; 1 Tim. 2:2; 1 Tim. 2:1</p></div>
+<p><strong>e.</strong> 2 Chron. 26:18; Matt. 18:17; Matt. 16:19, <strong>f.</strong> John 18:36; Acts 5:29; Eph. 4:11-12, <strong>g.</strong> Isa. 49:23; Rom. 13:1-6, <strong>h.</strong> Ps. 105:15, <strong>i.</strong> Rom. 13:4; 1 Tim. 2:2; 1 Tim. 2:1</p></div>
 </details>
 
 <p><span id="wcf-23-4"></span>4. It is the duty of people to pray for magistrates, to honor their persons,<sup class="proof-marker">l</sup> to pay them <span class="v-const">tribute</span><span class="v-modern">taxes</span> or other dues,<sup class="proof-marker">m</sup> to obey their lawful commands, and to be subject to their authority, for conscience' sake. Infidelity, or difference in religion, <span class="v-const">doth</span><span class="v-modern">does</span> not make void the magistrates' just and legal authority, nor free the people from their due obedience to them:<sup class="proof-marker">o</sup> from which ecclesiastical persons are not exempted,<sup class="proof-marker">p</sup> much less <span class="v-const">hath</span><span class="v-modern">has</span> the pope any power and jurisdiction over them in their dominions, or over any of their people; and, least of all, to deprive them of their dominions, or lives, if he shall judge them to be heretics, or upon any other pretense whatsoever.<sup class="proof-marker">q</sup></p>
@@ -1064,7 +1064,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-23-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> 1 Pet. 2:17, <strong>m.</strong> Matt. 22:21; Rom. 13:6–7, <strong>n.</strong> Rom. 13:5, <strong>o.</strong> 1 Pet. 2:13–16, <strong>p.</strong> Rom. 13:1; Acts 25:9–11</p></div>
+<p><strong>l.</strong> 1 Pet. 2:17, <strong>m.</strong> Matt. 22:21; Rom. 13:6-7, <strong>n.</strong> Rom. 13:5, <strong>o.</strong> 1 Pet. 2:13-16, <strong>p.</strong> Rom. 13:1; Acts 25:9-11</p></div>
 </details>
 
 ## CHAPTER 24: Of Marriage and Divorce
@@ -1073,7 +1073,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-24-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Gen. 2:24; Matt. 19:4–6</p>
+<p><strong>a.</strong> Gen. 2:24; Matt. 19:4-6</p>
 </div>
 </details>
 
@@ -1090,7 +1090,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-24-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>e.</strong> Heb. 13:4; 1 Tim. 4:3; 1 Cor. 7:36–38; Gen. 24:57–58, <strong>f.</strong> 1 Cor. 7:39, <strong>g.</strong> Gen. 34:14; 2 Cor. 6:14; Deut. 7:3–4; 1 Kings 11:4; Neh. 13:25–27; Mal. 2:11–12</p></div>
+<p><strong>e.</strong> Heb. 13:4; 1 Tim. 4:3; 1 Cor. 7:36-38; Gen. 24:57-58, <strong>f.</strong> 1 Cor. 7:39, <strong>g.</strong> Gen. 34:14; 2 Cor. 6:14; Deut. 7:3-4; 1 Kings 11:4; Neh. 13:25-27; Mal. 2:11-12</p></div>
 </details>
 
 <p><span id="wcf-24-4"></span>4. Marriage ought not to be within the degrees of consanguinity or affinity forbidden by the Word.<sup class="proof-marker">h</sup> Nor can such incestuous marriages ever be made lawful by any law of man or consent of parties, so <span class="v-const">as</span><span class="v-modern">that</span> those persons may live together as man and wife.<sup class="proof-marker">i</sup></p>
@@ -1098,7 +1098,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-24-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>h.</strong> Lev. 18:6–17, 24–30; Lev. 20:19; 1 Cor. 5:1; Amos 2:7, <strong>i.</strong> Mark 6:18; Lev. 18:24–28; Matt. 1:18–20; Deut. 22:23–24</p></div>
+<p><strong>h.</strong> Lev. 18:6-17, 24-30; Lev. 20:19; 1 Cor. 5:1; Amos 2:7, <strong>i.</strong> Mark 6:18; Lev. 18:24-28; Matt. 1:18-20; Deut. 22:23-24</p></div>
 </details>
 
 <p><span id="wcf-24-5"></span>5. Adultery or fornication committed after a contract, being detected before marriage, <span class="v-const">giveth</span><span class="v-modern">gives</span> just occasion to the innocent party to dissolve that contract. In the case of adultery after marriage, it is lawful for the innocent party to sue out a divorce:<sup class="proof-marker">l</sup> and, after the divorce, to marry another, as if the offending party were dead.<sup class="proof-marker">m</sup></p>
@@ -1125,7 +1125,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-25-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Eph. 1:10, 22–23; Eph. 5:23, 27, 32; Col. 1:18</p>
+<p><strong>a.</strong> Eph. 1:10, 22-23; Eph. 5:23, 27, 32; Col. 1:18</p>
 </div>
 </details>
 
@@ -1134,7 +1134,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-25-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>b.</strong> 1 Cor. 1:2; 1 Cor. 12:12–13; Ps. 2:8; Rev. 7:9; Rom. 15:9–12, <strong>c.</strong> 1 Cor. 7:14; Acts 2:39; Gen. 17:7–12, <strong>d.</strong> Matt. 13:47; Isa. 9:7; Luke 1:32–33; Acts 2:30–36; Col. 1:13, <strong>e.</strong> Eph. 2:19; Eph. 3:15, <strong>f.</strong> Acts 2:47</p></div>
+<p><strong>b.</strong> 1 Cor. 1:2; 1 Cor. 12:12-13; Ps. 2:8; Rev. 7:9; Rom. 15:9-12, <strong>c.</strong> 1 Cor. 7:14; Acts 2:39; Gen. 17:7-12, <strong>d.</strong> Matt. 13:47; Isa. 9:7; Luke 1:32-33; Acts 2:30-36; Col. 1:13, <strong>e.</strong> Eph. 2:19; Eph. 3:15, <strong>f.</strong> Acts 2:47</p></div>
 </details>
 
 <p><span id="wcf-25-3"></span>3. <span class="v-const">Unto</span><span class="v-modern">To</span> this catholic visible church Christ <span class="v-const">hath</span><span class="v-modern">has</span> given the ministry, oracles, and ordinances of God, for the gathering and perfecting of the saints, in this life, to the end of the world: <span class="v-const">and doth,</span><span class="v-modern">and,</span> by his own presence and Spirit, according to his promise, <span class="v-const">make</span><span class="v-modern">makes</span> them effectual <span class="v-const">thereunto.</span><span class="v-modern">for this.</span><sup class="proof-marker">g</sup></p>
@@ -1142,7 +1142,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-25-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>g.</strong> 1 Cor. 12:28; Eph. 4:11–13</p>
+<p><strong>g.</strong> 1 Cor. 12:28; Eph. 4:11-13</p>
 </div>
 </details>
 
@@ -1151,7 +1151,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-25-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>h.</strong> Rom. 11:3–5; Acts 9:31; Acts 2:41, 47; Acts 18:8–10, <strong>i.</strong> Acts 2:41–42; 1 Cor. 5:6–7</p></div>
+<p><strong>h.</strong> Rom. 11:3-5; Acts 9:31; Acts 2:41, 47; Acts 18:8-10, <strong>i.</strong> Acts 2:41-42; 1 Cor. 5:6-7</p></div>
 </details>
 
 <p><span id="wcf-25-5"></span>5. The purest churches under heaven are subject both to mixture and error; and some have so degenerated, as to become no churches of Christ, but synagogues of Satan.<sup class="proof-marker">l</sup> Nevertheless, there shall <span class="v-const">be always</span><span class="v-modern">always be</span> a church on earth, to worship God according to his will.<sup class="proof-marker">m</sup></p>
@@ -1159,7 +1159,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-25-5-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Matt. 23:37–39; Rom. 11:18–22, <strong>m.</strong> Matt. 16:18; Ps. 45:16–17; Ps. 72:17; Matt. 28:19–20</p></div>
+<p><strong>l.</strong> Matt. 23:37-39; Rom. 11:18-22, <strong>m.</strong> Matt. 16:18; Ps. 45:16-17; Ps. 72:17; Matt. 28:19-20</p></div>
 </details>
 
 <p><span id="wcf-25-6"></span>6. There is no other head of the church but the Lord Jesus Christ.<sup class="proof-marker">n</sup> Nor can the pope of Rome, in any sense, be <span class="v-const">head thereof.</span><span class="v-modern">its head.</span><sup class="proof-marker">o</sup></p>
@@ -1167,7 +1167,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-25-6-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>n.</strong> Matt. 19:8–9; 1 Cor. 7:15; Matt. 19:6, <strong>o.</strong> Deut. 24:1–4</p></div>
+<p><strong>n.</strong> Matt. 19:8-9; 1 Cor. 7:15; Matt. 19:6, <strong>o.</strong> Deut. 24:1-4</p></div>
 </details>
 
 ## CHAPTER 26: Of the Communion of Saints
@@ -1176,7 +1176,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-26-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> 1 John 1:3; Eph. 3:16–18; John 1:16; Eph. 2:5–6; Phil. 3:10; Rom. 6:5–6; Rom. 8:17, <strong>b.</strong> Eph. 4:15–16; 1 Cor. 12:7, 12; 1 Cor. 3:21–23; Col. 2:19, <strong>c.</strong> 1 Thess. 5:11, 14; Rom. 1:11–12, 14; 1 John 3:16–18; Gal. 6:10</p></div>
+<p><strong>a.</strong> 1 John 1:3; Eph. 3:16-18; John 1:16; Eph. 2:5-6; Phil. 3:10; Rom. 6:5-6; Rom. 8:17, <strong>b.</strong> Eph. 4:15-16; 1 Cor. 12:7, 12; 1 Cor. 3:21-23; Col. 2:19, <strong>c.</strong> 1 Thess. 5:11, 14; Rom. 1:11-12, 14; 1 John 3:16-18; Gal. 6:10</p></div>
 </details>
 
 <p><span id="wcf-26-2"></span>2. Saints by profession are bound to maintain <span cl<span class="v-const">as</span><span class="v-modern">and</span>s="v-const">an</span><span class="v-modern">a</span> holy fellowship and communion in the worship of God, and in performing such other spiritual services as tend to their mutual edification;<sup class="proof-marker">d</sup> as also in relieving each other in outward things, according to their several abilities and necessities. <span class="v-const">Which</span><span class="v-modern">Such</span> communion, as God <span class="v-const">offereth</span><span class="v-modern">offers</span> opportunity, is to be extended <span class="v-const">unto</span><span class="v-modern">to</span> all those who, in every place, call upon the name of the Lord Jesus.<sup class="proof-marker">e</sup></p>
@@ -1184,7 +1184,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-26-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>d.</strong> Heb. 10:24–25; Acts 2:42, 46; Isa. 2:3, <strong>e.</strong> 1 John 3:17; Acts 11:29–30; Acts 2:44–45</p></div>
+<p><strong>d.</strong> Heb. 10:24-25; Acts 2:42, 46; Isa. 2:3, <strong>e.</strong> 1 John 3:17; Acts 11:29-30; Acts 2:44-45</p></div>
 </details>
 
 <p><span id="wcf-26-3"></span>3. This communion <span class="v-const">which</span><span class="v-modern">that</span> the saints have with Christ, <span class="v-const">doth</span><span class="v-modern">does</span> not make them in any <span class="v-const">wise</span><span class="v-modern">way</span> partakers of the substance of his Godhead; or to be equal with Christ in any respect: <span class="v-modern">to affirm</span> either of which <span class="v-const">to affirm</span> is impious and blasphemous.<sup class="proof-marker">f</sup> Nor <span class="v-const">doth</span><span class="v-modern">does</span> their communion <span class="v-const">one with</span><span class="v-modern">with one</span> another, as saints, take away, or infringe the title or <span class="v-const">propriety which</span><span class="v-modern">ownership that</span> each man <span class="v-const">hath in</span><span class="v-modern">has of</span> his goods and possessions.<sup class="proof-marker">g</sup></p>
@@ -1192,7 +1192,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-26-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>f.</strong> Col. 1:18–19; 1 Cor. 8:6; Ps. 45:6–7; Heb. 1:6–9; John 1:14; John 20:17, <strong>g.</strong> Eph. 4:28</p></div>
+<p><strong>f.</strong> Col. 1:18-19; 1 Cor. 8:6; Ps. 45:6-7; Heb. 1:6-9; John 1:14; John 20:17, <strong>g.</strong> Eph. 4:28</p></div>
 </details>
 
 ## CHAPTER 27:Of the Sacraments
@@ -1201,7 +1201,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-27-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Rom. 4:11; Gen. 17:7, 10–11, <strong>b.</strong> Matt. 28:19; 1 Cor. 11:23, <strong>c.</strong> Rom. 6:3–4; Col. 2:12; 1 Cor. 10:16; 1 Cor. 11:25–26; Gal. 3:27, <strong>d.</strong> Gen. 34:14; 1 Cor. 10:21, <strong>e.</strong> Rom. 6:3–4; Gal. 3:27; 1 Pet. 3:21; 1 Cor. 10:16; 1 Cor. 5:7–8</p></div>
+<p><strong>a.</strong> Rom. 4:11; Gen. 17:7, 10-11, <strong>b.</strong> Matt. 28:19; 1 Cor. 11:23, <strong>c.</strong> Rom. 6:3-4; Col. 2:12; 1 Cor. 10:16; 1 Cor. 11:25-26; Gal. 3:27, <strong>d.</strong> Gen. 34:14; 1 Cor. 10:21, <strong>e.</strong> Rom. 6:3-4; Gal. 3:27; 1 Pet. 3:21; 1 Cor. 10:16; 1 Cor. 5:7-8</p></div>
 </details>
 
 <p><span id="wcf-27-2"></span>2. There is, in every sacrament, a spiritual relation, or sacramental union, between the sign and the thing signified: <span class="v-const">whence</span><span class="v-modern">from which</span> it comes to pass, that the names and effects of the one are attributed to the other.<sup class="proof-marker">f</sup></p>
@@ -1209,7 +1209,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-27-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>f.</strong> Gen. 17:10; Matt. 26:27–28; 1 Cor. 10:16–18</p>
+<p><strong>f.</strong> Gen. 17:10; Matt. 26:27-28; 1 Cor. 10:16-18</p>
 </div>
 </details>
 
@@ -1218,7 +1218,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-27-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>g.</strong> Rom. 2:28–29; 1 Pet. 3:21, <strong>h.</strong> 1 Cor. 12:13, <strong>i.</strong> Matt. 26:26–28; Luke 22:19–20</p></div>
+<p><strong>g.</strong> Rom. 2:28-29; 1 Pet. 3:21, <strong>h.</strong> 1 Cor. 12:13, <strong>i.</strong> Matt. 26:26-28; Luke 22:19-20</p></div>
 </details>
 
 <p><span id="wcf-27-4"></span>4. There <span class="v-const">be</span><span class="v-modern">are</span> only two sacraments ordained by Christ our Lord in the <span class="v-const">Gospel; that is to say,</span><span class="v-modern">gospel:</span> baptism, and the Supper of the <span class="v-const">Lord:</span><span class="v-modern">Lord,</span> neither of which may be dispensed by any, but by a minister of the Word lawfully ordained.</p>
@@ -1245,7 +1245,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-28-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Matt. 28:19, <strong>b.</strong> 1 Cor. 12:13; Gal. 3:27–28, <strong>c.</strong> Rom. 4:11; Col. 2:11–12, <strong>d.</strong> Gal. 3:27; Rom. 6:5, <strong>e.</strong> John 3:5, <strong>f.</strong> Mark 1:4; Acts 2:38; Acts 22:16, <strong>g.</strong> Rom. 6:3–4, <strong>h.</strong> Matt. 28:19–20</p></div>
+<p><strong>a.</strong> Matt. 28:19, <strong>b.</strong> 1 Cor. 12:13; Gal. 3:27-28, <strong>c.</strong> Rom. 4:11; Col. 2:11-12, <strong>d.</strong> Gal. 3:27; Rom. 6:5, <strong>e.</strong> John 3:5, <strong>f.</strong> Mark 1:4; Acts 2:38; Acts 22:16, <strong>g.</strong> Rom. 6:3-4, <strong>h.</strong> Matt. 28:19-20</p></div>
 </details>
 
 <p><span id="wcf-28-2"></span>2. The outward element to be used in this sacrament is water, <span class="v-const">wherewith</span><span class="v-modern">with which</span> the party is to be baptized, in the name of the Father, and of the Son, and of the Holy <span class="v-const">Ghost,</span><span class="v-modern">Spirit,</span> by a <span class="v-modern">lawfully called</span> minister of the <span class="v-const">gospel, lawfully called thereunto.</span><span class="v-modern">gospel.</span><sup class="proof-marker">i</sup></p>
@@ -1271,7 +1271,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-28-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Acts 2:41; Acts 8:12–13; Acts 16:14–15, <strong>m.</strong> Gen. 17:7–14; Gal. 3:9, 14; Col. 2:11–12</p></div>
+<p><strong>l.</strong> Acts 2:41; Acts 8:12-13; Acts 16:14-15, <strong>m.</strong> Gen. 17:7-14; Gal. 3:9, 14; Col. 2:11-12</p></div>
 </details>
 
 <p><span id="wcf-28-5"></span>5. Although it <span class="v-const">be</span><span class="v-modern">is</span> a great sin to <span class="v-const">contemn</span><span class="v-modern">disdain</span> or neglect this ordinance,<sup class="proof-marker">n</sup> yet grace and salvation are not so inseparably annexed <span class="v-const">unto</span><span class="v-modern">to</span> it, <span class="v-const">as</span> that no person can be regenerated, or saved, without it;<sup class="proof-marker">o</sup> or, that all that are baptized are undoubtedly regenerated.<sup class="proof-marker">p</sup></p>
@@ -1287,7 +1287,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-28-6-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>q.</strong> John 3:5, 8, <strong>r.</strong> Rom. 6:3–6; Gal. 3:27; 1 Pet. 3:21; Acts 2:38, 41</p></div>
+<p><strong>q.</strong> John 3:5, 8, <strong>r.</strong> Rom. 6:3-6; Gal. 3:27; 1 Pet. 3:21; Acts 2:38, 41</p></div>
 </details>
 
 <p><span id="wcf-28-7"></span>7. The sacrament of baptism is <span class="v-const">but once</span> to be administered <span class="v-const">unto</span><span class="v-modern">to</span> any <span class="v-const">person.</span><span class="v-modern">person only once.</span><sup class="proof-marker">s</sup></p>
@@ -1295,7 +1295,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-28-7-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>s.</strong> Rom. 6:3–11</p>
+<p><strong>s.</strong> Rom. 6:3-11</p>
 </div>
 </details>
 
@@ -1305,7 +1305,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-29-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> 1 Cor. 11:23–26; 1 Cor. 10:16–17, 21; 1 Cor. 12:13</p>
+<p><strong>a.</strong> 1 Cor. 11:23-26; 1 Cor. 10:16-17, 21; 1 Cor. 12:13</p>
 </div>
 </details>
 
@@ -1314,7 +1314,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-29-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>b.</strong> Heb. 9:22, 25–26, 28; Heb. 10:10–14, <strong>c.</strong> 1 Cor. 11:24–26; Matt. 26:26–27; Luke 22:19–20, <strong>d.</strong> Heb. 7:23–24, 27; Heb. 10:11–12, 14, 18</p></div>
+<p><strong>b.</strong> Heb. 9:22, 25-26, 28; Heb. 10:10-14, <strong>c.</strong> 1 Cor. 11:24-26; Matt. 26:26-27; Luke 22:19-20, <strong>d.</strong> Heb. 7:23-24, 27; Heb. 10:11-12, 14, 18</p></div>
 </details>
 
 <p><span id="wcf-29-3"></span>3. The Lord Jesus <span class="v-const">hath,</span><span class="v-modern">has,</span> in this ordinance, appointed his ministers to declare his word of institution to the people; to pray, and bless the elements of bread and wine, and <span class="v-const">thereby</span><span class="v-modern">in this way</span> to set them apart from a common to <span class="v-const">an</span><span class="v-modern">a</span> holy use; and to take and break the bread, to take the cup, and (they <span class="v-const">communicating</span><span class="v-modern">partaking</span> also themselves) to give both to the communicants;<sup class="proof-marker">e</sup> but to none who are not then present in the congregation.<sup class="proof-marker">f</sup></p>
@@ -1322,7 +1322,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-29-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>e.</strong> Matt. 26:26–28; Mark 14:22–24; Luke 22:19–20, <strong>f.</strong> Acts 20:7; 1 Cor. 11:20</p></div>
+<p><strong>e.</strong> Matt. 26:26-28; Mark 14:22-24; Luke 22:19-20, <strong>f.</strong> Acts 20:7; 1 Cor. 11:20</p></div>
 </details>
 
 <p><span id="wcf-29-4"></span>4. Private <span class="v-const">masses,</span><span class="v-modern">Masses,</span> or receiving this sacrament by a priest, or any other, alone;<sup class="proof-marker">g</sup> as likewise, the denial of the cup to the people,<sup class="proof-marker">h</sup> worshiping the elements, <span class="v-const">the</span> lifting them up, or carrying them about, for adoration, and <span class="v-const">the</span> reserving them for any pretended religious use; are all contrary to the nature of this sacrament, and to the institution of Christ.<sup class="proof-marker">i</sup></p>
@@ -1330,7 +1330,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-29-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>g.</strong> 1 Cor. 10:16, <strong>h.</strong> Matt. 26:27–28; Mark 14:23; 1 Cor. 11:25–29, <strong>i.</strong> Matt. 15:9; Matt. 26:26–28</p></div>
+<p><strong>g.</strong> 1 Cor. 10:16, <strong>h.</strong> Matt. 26:27-28; Mark 14:23; 1 Cor. 11:25-29, <strong>i.</strong> Matt. 15:9; Matt. 26:26-28</p></div>
 </details>
 
 <p><span id="wcf-29-5"></span>5. The outward elements in this sacrament, duly set apart to the uses ordained by Christ, have such relation to him crucified, <span class="v-const">as</span> that, truly, yet sacramentally only, they are sometimes called by the name of the things they represent, <span class="v-const">to wit,</span><span class="v-modern">that is,</span> the body and blood of Christ; <span class="v-const">albeit,</span><span class="v-modern">although,</span> in substance and nature, they still remain truly and only bread and wine, as they were before.<sup class="proof-marker">l</sup></p>
@@ -1338,7 +1338,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-29-5-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> 1 Cor. 11:26–28; Matt. 26:29</p>
+<p><strong>l.</strong> 1 Cor. 11:26-28; Matt. 26:29</p>
 </div>
 </details>
 
@@ -1347,7 +1347,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-29-6-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>m.</strong> Acts 3:21; 1 Cor. 11:24–26; Luke 24:6, 39</p>
+<p><strong>m.</strong> Acts 3:21; 1 Cor. 11:24-26; Luke 24:6, 39</p>
 </div>
 </details>
 
@@ -1356,7 +1356,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-29-7-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>n.</strong> 1 Cor. 11:28, <strong>o.</strong> 1 Cor. 10:16; 1 Cor. 10:3–4</p></div>
+<p><strong>n.</strong> 1 Cor. 11:28, <strong>o.</strong> 1 Cor. 10:16; 1 Cor. 10:3-4</p></div>
 </details>
 
 <p><span id="wcf-29-8"></span>8. Although ignorant and wicked men receive the outward elements in this sacrament; yet, they <span class="v-modern">do not</span> receive <span class="v-const">not</span> the thing signified <span class="v-const">thereby;</span><span class="v-modern">by them;</span> but, by their unworthy coming <span class="v-const">thereunto,</span><span class="v-modern">to it,</span> are guilty of the body and blood of the Lord, to their own damnation. <span class="v-const">Wherefore,</span><span class="v-modern">Therefore,</span> all ignorant and ungodly persons, as they are unfit to enjoy communion with him, so are they unworthy of the Lord's table; and <span class="v-const">cannot, without great sin against Christ, while they remain such,</span><span class="v-modern">cannot</span> partake of these holy mysteries,<sup class="proof-marker">p</sup> or be admitted <span class="v-const">thereunto.</span><span class="v-modern">to them, while they remain such, without great sin against Christ.</span><sup class="proof-marker">q</sup></p>
@@ -1374,7 +1374,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-30-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Isa. 9:6–7; Col. 1:18</p>
+<p><strong>a.</strong> Isa. 9:6-7; Col. 1:18</p>
 </div>
 </details>
 
@@ -1383,7 +1383,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-30-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>b.</strong> Matt. 16:19; Matt. 18:17–18; John 20:21–23</p>
+<p><strong>b.</strong> Matt. 16:19; Matt. 18:17-18; John 20:21-23</p>
 </div>
 </details>
 
@@ -1401,7 +1401,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-30-4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>d.</strong> 1 Thess. 5:12; 2 Thess. 3:6, 14–15; 1 Cor. 5:4–5, 13</p>
+<p><strong>d.</strong> 1 Thess. 5:12; 2 Thess. 3:6, 14-15; 1 Cor. 5:4-5, 13</p>
 </div>
 </details>
 
@@ -1411,7 +1411,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-31-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Acts 15:2, 4, 6, <strong>b.</strong> Acts 15:1–35, <strong>c.</strong> Acts 15:1–35; Acts 20:17</p></div>
+<p><strong>a.</strong> Acts 15:2, 4, 6, <strong>b.</strong> Acts 15:1-35, <strong>c.</strong> Acts 15:1-35; Acts 20:17</p></div>
 </details>
 
 <p><span id="wcf-31-2"></span>2. It <span class="v-const">belongeth</span><span class="v-modern">belongs</span> to synods and councils, ministerially to determine controversies of faith, and cases of conscience; to set down rules and directions for the better ordering of the public worship of God, and government of his church; to receive complaints in cases of maladministration, and authoritatively to determine the same: <span class="v-const">which</span><span class="v-modern">these</span> decrees and determinations, if consonant to the Word of God, are to be received with reverence and submission; not only for their agreement with the Word, but also for the power <span class="v-const">whereby</span><span class="v-modern">by which</span> they are made, as being an ordinance of God appointed <span class="v-const">thereunto</span><span class="v-modern">for these purposes</span> in his Word.<sup class="proof-marker">d</sup></p>
@@ -1419,7 +1419,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-31-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>d.</strong> Acts 15:15, 19, 24, 27–31; Acts 16:4; Matt. 18:17–20</p>
+<p><strong>d.</strong> Acts 15:15, 19, 24, 27-31; Acts 16:4; Matt. 18:17-20</p>
 </div>
 </details>
 
@@ -1428,7 +1428,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-31-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>e.</strong> Eph. 2:20; Acts 17:11; 1 Cor. 2:5; 2 Cor. 1:24; Isa. 8:19–20; Matt. 15:9</p>
+<p><strong>e.</strong> Eph. 2:20; Acts 17:11; 1 Cor. 2:5; 2 Cor. 1:24; Isa. 8:19-20; Matt. 15:9</p>
 </div>
 </details>
 
@@ -1447,7 +1447,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-32-1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Gen. 3:19; Acts 13:36, <strong>b.</strong> Luke 23:43, <strong>c.</strong> Heb. 12:23; 2 Cor. 5:1, 6, 8; Phil. 1:23; Acts 3:21; Eph. 4:10; Rom. 8:23, <strong>d.</strong> Luke 16:23–24; Acts 1:25; 1 Pet. 3:19</p></div>
+<p><strong>a.</strong> Gen. 3:19; Acts 13:36, <strong>b.</strong> Luke 23:43, <strong>c.</strong> Heb. 12:23; 2 Cor. 5:1, 6, 8; Phil. 1:23; Acts 3:21; Eph. 4:10; Rom. 8:23, <strong>d.</strong> Luke 16:23-24; Acts 1:25; 1 Pet. 3:19</p></div>
 </details>
 
 <p><span id="wcf-32-2"></span>2. At the last day, <span class="v-const">such as</span><span class="v-modern">those who</span> are found alive shall not die, but be changed:<sup class="proof-marker">e</sup> and all the dead shall be raised up, with the selfsame bodies, and none other (although with different qualities), which shall be united again to their souls forever.<sup class="proof-marker">f</sup></p>
@@ -1455,7 +1455,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-32-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>e.</strong> 1 Thess. 4:17; 1 Cor. 15:51–52, <strong>f.</strong> John 5:25–29; Acts 24:15; Job 19:26–27; Dan. 12:2; 1 Cor. 15:42–44</p></div>
+<p><strong>e.</strong> 1 Thess. 4:17; 1 Cor. 15:51-52, <strong>f.</strong> John 5:25-29; Acts 24:15; Job 19:26-27; Dan. 12:2; 1 Cor. 15:42-44</p></div>
 </details>
 
 <p><span id="wcf-32-3"></span>3. The bodies of the unjust shall, by the power of Christ, be raised to dishonor: the bodies of the just, by his Spirit, <span class="v-const">unto</span><span class="v-modern">to</span> honor; and be made conformable to his own glorious body.<sup class="proof-marker">g</sup></p>
@@ -1481,7 +1481,7 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-33-2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>e.</strong> Matt. 25:31–46; Rom. 2:5–6; Rom. 9:22–23; Matt. 25:21; Acts 3:19; 2 Thess. 1:7–10; Mark 9:48</p>
+<p><strong>e.</strong> Matt. 25:31-46; Rom. 2:5-6; Rom. 9:22-23; Matt. 25:21; Acts 3:19; 2 Thess. 1:7-10; Mark 9:48</p>
 </div>
 </details>
 
@@ -1492,6 +1492,6 @@ All <span class="v-const">which</span><span class="v-modern">of these</span> are
 <details class="scripture-proofs" id="wcf-33-3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>f.</strong> 2 Pet. 3:11, 14; 2 Cor. 5:10–11; 2 Thess. 1:5–7; Luke 21:27–28; Rom. 8:23–25, <strong>g.</strong> Matt. 24:36, 42–44; Mark 13:35–37; Luke 12:35–36; Rev. 22:20</p></div>
+<p><strong>f.</strong> 2 Pet. 3:11, 14; 2 Cor. 5:10-11; 2 Thess. 1:5-7; Luke 21:27-28; Rom. 8:23-25, <strong>g.</strong> Matt. 24:36, 42-44; Mark 13:35-37; Luke 12:35-36; Rev. 22:20</p></div>
 </details>
 

--- a/_pages/wlc.md
+++ b/_pages/wlc.md
@@ -13,7 +13,7 @@ Answer: Man's chief and highest end is to glorify God,<sup class="proof-marker">
 <details class="scripture-proofs" id="wlc-q1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Rom. 11:36; 1 Cor. 6:20; 1 Cor. 10:31; Ps. 86:9, 12, <strong>b.</strong> Ps. 73:24–28; John 17:21–23; Ps. 16:5–11; Rev. 21:3–4</p></div>
+<p><strong>a.</strong> Rom. 11:36; 1 Cor. 6:20; 1 Cor. 10:31; Ps. 86:9, 12, <strong>b.</strong> Ps. 73:24-28; John 17:21-23; Ps. 16:5-11; Rev. 21:3-4</p></div>
 </details>
 
 
@@ -36,7 +36,7 @@ Answer: The Holy Scriptures of the Old and New Testament are the Word of God,<su
 <details class="scripture-proofs" id="wlc-q3-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>c.</strong> Rom. 1:19–20; Acts 17:28; Ps. 19:1–3, <strong>d.</strong> 1 Cor. 2:9–10; 1 Cor. 1:20–21; 2 Tim. 3:15–17; Isa. 59:21, <strong>e.</strong> 2 Tim. 3:16; 2 Pet. 1:19–21; 2 Pet. 3:2, 15–16; Matt. 19:4–5; Gen. 2:24</p></div>
+<p><strong>c.</strong> Rom. 1:19-20; Acts 17:28; Ps. 19:1-3, <strong>d.</strong> 1 Cor. 2:9-10; 1 Cor. 1:20-21; 2 Tim. 3:15-17; Isa. 59:21, <strong>e.</strong> 2 Tim. 3:16; 2 Pet. 1:19-21; 2 Pet. 3:2, 15-16; Matt. 19:4-5; Gen. 2:24</p></div>
 </details>
 
 
@@ -47,7 +47,7 @@ Answer: The Scriptures manifest themselves to be the Word of God, by their majes
 <details class="scripture-proofs" id="wlc-q4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>f.</strong> Deut. 4:2; Eph. 2:20; Rev. 22:18–19; Isa. 8:20; Luke 16:29, 31; Gal. 1:8–9; 2 Tim. 3:15–16, <strong>g.</strong> Hos. 8:12; 1 Cor. 2:6–7, 13; Ps. 119:18, 129, <strong>h.</strong> Ps. 12:6; Ps. 119:140, <strong>i.</strong> Luke 24:27; Acts 10:43; Acts 26:22; Rom. 3:19, 27</p></div>
+<p><strong>f.</strong> Deut. 4:2; Eph. 2:20; Rev. 22:18-19; Isa. 8:20; Luke 16:29, 31; Gal. 1:8-9; 2 Tim. 3:15-16, <strong>g.</strong> Hos. 8:12; 1 Cor. 2:6-7, 13; Ps. 119:18, 129, <strong>h.</strong> Ps. 12:6; Ps. 119:140, <strong>i.</strong> Luke 24:27; Acts 10:43; Acts 26:22; Rom. 3:19, 27</p></div>
 </details>
 
 
@@ -58,7 +58,7 @@ Answer: The Scriptures principally teach what man is to believe concerning God,<
 <details class="scripture-proofs" id="wlc-q5-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Acts 18:28; Heb. 4:12; Ps. 19:7–9; Rom. 15:4; Acts 20:32, <strong>m.</strong> John 16:13–14; 1 John 2:20, 27; John 20:31, <strong>n.</strong> Gen. 1:1; Ps. 48:1; John 20:31; 2 Tim. 3:15</p></div>
+<p><strong>l.</strong> Acts 18:28; Heb. 4:12; Ps. 19:7-9; Rom. 15:4; Acts 20:32, <strong>m.</strong> John 16:13-14; 1 John 2:20, 27; John 20:31, <strong>n.</strong> Gen. 1:1; Ps. 48:1; John 20:31; 2 Tim. 3:15</p></div>
 </details>
 
 
@@ -71,7 +71,7 @@ Answer: The Scriptures make known what God is,<sup class="proof-marker">p</sup> 
 <details class="scripture-proofs" id="wlc-q6-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>o.</strong> Deut. 10:12–13; 2 Tim. 3:15–17; Acts 16:30–31, <strong>p.</strong> John 4:24; Isa. 40:18, 21–23, 25, 28; Heb. 11:6, <strong>q.</strong> Matt. 3:16–17; Deut. 6:4–6; 1 Cor. 8:4, 6; Matt. 28:19–20; 2 Cor. 13:14</p></div>
+<p><strong>o.</strong> Deut. 10:12-13; 2 Tim. 3:15-17; Acts 16:30-31, <strong>p.</strong> John 4:24; Isa. 40:18, 21-23, 25, 28; Heb. 11:6, <strong>q.</strong> Matt. 3:16-17; Deut. 6:4-6; 1 Cor. 8:4, 6; Matt. 28:19-20; 2 Cor. 13:14</p></div>
 </details>
 
 
@@ -82,7 +82,7 @@ Answer: God is a Spirit,<sup class="proof-marker">t</sup> in and of himself infi
 <details class="scripture-proofs" id="wlc-q7-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Ps. 90:2; Deut. 33:27, <strong>b.</strong> Mal. 3:6, <strong>c.</strong> 1 Kings 8:27, <strong>d.</strong> Ps. 139:1–13, <strong>e.</strong> Rev. 4:8; Gen. 17:1; Matt. 19:26, <strong>f.</strong> Heb. 4:13; Ps. 147:5, <strong>g.</strong> Rom. 11:33–34; Rom. 16:27, <strong>h.</strong> 1 Pet. 1:15–16; Rev. 15:4; Isa. 6:3, <strong>i.</strong> Deut. 32:4; Rom. 3:5, 26; Ps. 117:2, <strong>r.</strong> Acts 15:14–15, 18; Isa. 46:9–10, <strong>s.</strong> Acts 4:27–28, <strong>t.</strong> John 4:24, <strong>u.</strong> Job 11:7–9; Ps. 145:3; Ps. 147:5, <strong>w.</strong> Acts 7:2, <strong>x.</strong> 1 Tim. 6:15, <strong>y.</strong> Matt. 5:48, <strong>z.</strong> Gen. 17:1; Rom. 11:35–36</p></div>
+<p><strong>a.</strong> Ps. 90:2; Deut. 33:27, <strong>b.</strong> Mal. 3:6, <strong>c.</strong> 1 Kings 8:27, <strong>d.</strong> Ps. 139:1-13, <strong>e.</strong> Rev. 4:8; Gen. 17:1; Matt. 19:26, <strong>f.</strong> Heb. 4:13; Ps. 147:5, <strong>g.</strong> Rom. 11:33-34; Rom. 16:27, <strong>h.</strong> 1 Pet. 1:15-16; Rev. 15:4; Isa. 6:3, <strong>i.</strong> Deut. 32:4; Rom. 3:5, 26; Ps. 117:2, <strong>r.</strong> Acts 15:14-15, 18; Isa. 46:9-10, <strong>s.</strong> Acts 4:27-28, <strong>t.</strong> John 4:24, <strong>u.</strong> Job 11:7-9; Ps. 145:3; Ps. 147:5, <strong>w.</strong> Acts 7:2, <strong>x.</strong> 1 Tim. 6:15, <strong>y.</strong> Matt. 5:48, <strong>z.</strong> Gen. 17:1; Rom. 11:35-36</p></div>
 </details>
 
 
@@ -105,7 +105,7 @@ Answer: There <span class="v-const">be</span><span class="v-modern">are</span> t
 <details class="scripture-proofs" id="wlc-q9-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Deut. 6:4; 1 Cor. 8:4, 6; Isa. 45:21–22; Isa. 44:6, <strong>m.</strong> Jer. 10:10; John 17:3; 1 Thess. 1:9; 1 John 5:20, <strong>n.</strong> Matt. 3:16–17; Matt. 28:19; 2 Cor. 13:14, <strong>o.</strong> John 1:1; Gen. 1:1–3; John 17:5; John 10:30; Ps. 45:6; Heb. 1:8–9; Acts 5:3–4</p></div>
+<p><strong>l.</strong> Deut. 6:4; 1 Cor. 8:4, 6; Isa. 45:21-22; Isa. 44:6, <strong>m.</strong> Jer. 10:10; John 17:3; 1 Thess. 1:9; 1 John 5:20, <strong>n.</strong> Matt. 3:16-17; Matt. 28:19; 2 Cor. 13:14, <strong>o.</strong> John 1:1; Gen. 1:1-3; John 17:5; John 10:30; Ps. 45:6; Heb. 1:8-9; Acts 5:3-4</p></div>
 </details>
 
 
@@ -128,7 +128,7 @@ Answer: The Scriptures manifest that the Son and the Holy <span class="v-const">
 <details class="scripture-proofs" id="wlc-q11-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>p.</strong> Heb. 1:5–6, 8, <strong>q.</strong> John 1:14, 18, <strong>r.</strong> John 15:26; Gal. 4:6, <strong>s.</strong> Isa. 6:3, 5, 8; John 12:41; Acts 28:25; 1 John 5:20; Acts 5:3–4, <strong>t.</strong> John 1:1; Isa. 9:6</p></div>
+<p><strong>p.</strong> Heb. 1:5-6, 8, <strong>q.</strong> John 1:14, 18, <strong>r.</strong> John 15:26; Gal. 4:6, <strong>s.</strong> Isa. 6:3, 5, 8; John 12:41; Acts 28:25; 1 John 5:20; Acts 5:3-4, <strong>t.</strong> John 1:1; Isa. 9:6</p></div>
 </details>
 
 
@@ -139,7 +139,7 @@ Answer: God's decrees are the wise, free, and holy acts of the counsel of his wi
 <details class="scripture-proofs" id="wlc-q12-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>u.</strong> Col. 1:16; Gen. 1:2, <strong>w.</strong> Matt. 28:19; 2 Cor. 13:14, <strong>x.</strong> Isa. 45:6–7; Eph. 1:11; Rom. 11:33; Rom. 9:14–15, 18, <strong>y.</strong> Ps. 33:11; Isa. 14:24; Acts 2:23; Acts 4:27–28; Rom. 9:22–23; Eph. 1:4, 11</p></div>
+<p><strong>u.</strong> Col. 1:16; Gen. 1:2, <strong>w.</strong> Matt. 28:19; 2 Cor. 13:14, <strong>x.</strong> Isa. 45:6-7; Eph. 1:11; Rom. 11:33; Rom. 9:14-15, 18, <strong>y.</strong> Ps. 33:11; Isa. 14:24; Acts 2:23; Acts 4:27-28; Rom. 9:22-23; Eph. 1:4, 11</p></div>
 </details>
 
 
@@ -162,7 +162,7 @@ Answer: God <span class="v-const">executeth</span><span class="v-modern">execute
 <details class="scripture-proofs" id="wlc-q14-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Eph. 1:4–6; Eph. 2:10; 2 Thess. 2:13–14; 1 Pet. 1:2, <strong>b.</strong> Rom. 9:17–18, 21–22; Matt. 11:25–26; 2 Tim. 2:20; 1 Pet. 2:8, <strong>z.</strong> 1 Tim. 5:21</p></div>
+<p><strong>a.</strong> Eph. 1:4-6; Eph. 2:10; 2 Thess. 2:13-14; 1 Pet. 1:2, <strong>b.</strong> Rom. 9:17-18, 21-22; Matt. 11:25-26; 2 Tim. 2:20; 1 Pet. 2:8, <strong>z.</strong> 1 Tim. 5:21</p></div>
 </details>
 
 
@@ -185,7 +185,7 @@ Answer: God created all the angels spirits, immortal,<sup class="proof-marker">h
 <details class="scripture-proofs" id="wlc-q16-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>c.</strong> Rev. 4:11; Isa. 40:12–31, <strong>d.</strong> Eph. 1:11; Ps. 148:8; Dan. 4:35; Acts 4:24–28, <strong>e.</strong> Gen. 1:1; Ps. 33:6, 9; Heb. 11:3; Rev. 4:11; Rom. 11:36, <strong>f.</strong> Col. 1:16, <strong>g.</strong> Ps. 104:4, <strong>h.</strong> Matt. 22:30; Luke 20:36, <strong>i.</strong> Matt. 25:31</p></div>
+<p><strong>c.</strong> Rev. 4:11; Isa. 40:12-31, <strong>d.</strong> Eph. 1:11; Ps. 148:8; Dan. 4:35; Acts 4:24-28, <strong>e.</strong> Gen. 1:1; Ps. 33:6, 9; Heb. 11:3; Rev. 4:11; Rom. 11:36, <strong>f.</strong> Col. 1:16, <strong>g.</strong> Ps. 104:4, <strong>h.</strong> Matt. 22:30; Luke 20:36, <strong>i.</strong> Matt. 25:31</p></div>
 </details>
 
 
@@ -196,7 +196,7 @@ Answer: After God had made all other creatures, he created man male and female;<
 <details class="scripture-proofs" id="wlc-q17-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> 2 Thess. 1:7, <strong>m.</strong> Ps. 91:11–12; Ps. 103:20–21, <strong>n.</strong> 2 Pet. 2:4, <strong>o.</strong> Gen. 1:27; Matt. 19:4, <strong>p.</strong> Gen. 2:7, <strong>q.</strong> Gen. 2:22, <strong>r.</strong> Gen. 2:7; Job 35:11; Matt. 10:28; Luke 23:43, <strong>s.</strong> Gen. 1:26–27, <strong>t.</strong> Col. 3:10</p></div>
+<p><strong>l.</strong> 2 Thess. 1:7, <strong>m.</strong> Ps. 91:11-12; Ps. 103:20-21, <strong>n.</strong> 2 Pet. 2:4, <strong>o.</strong> Gen. 1:27; Matt. 19:4, <strong>p.</strong> Gen. 2:7, <strong>q.</strong> Gen. 2:22, <strong>r.</strong> Gen. 2:7; Job 35:11; Matt. 10:28; Luke 23:43, <strong>s.</strong> Gen. 1:26-27, <strong>t.</strong> Col. 3:10</p></div>
 </details>
 
 
@@ -207,7 +207,7 @@ Answer: God's works of providence are his most holy,<sup class="proof-marker">a<
 <details class="scripture-proofs" id="wlc-q18-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Ps. 145:17; Lev. 21:8, <strong>b.</strong> Ps. 104:24; Isa. 28:29, <strong>c.</strong> Heb. 1:3; Ps. 36:6; Neh. 9:6, <strong>d.</strong> Ps. 103:19; Ps. 145:14–16, <strong>u.</strong> Eph. 4:24, <strong>w.</strong> Rom. 2:14–15, <strong>y.</strong> Gen. 1:28; Ps. 8:6–8, <strong>z.</strong> Gen. 2:16–17; Gen. 3:6</p></div>
+<p><strong>a.</strong> Ps. 145:17; Lev. 21:8, <strong>b.</strong> Ps. 104:24; Isa. 28:29, <strong>c.</strong> Heb. 1:3; Ps. 36:6; Neh. 9:6, <strong>d.</strong> Ps. 103:19; Ps. 145:14-16, <strong>u.</strong> Eph. 4:24, <strong>w.</strong> Rom. 2:14-15, <strong>y.</strong> Gen. 1:28; Ps. 8:6-8, <strong>z.</strong> Gen. 2:16-17; Gen. 3:6</p></div>
 </details>
 
 
@@ -230,7 +230,7 @@ Answer: The providence of God toward man in the <span class="v-const">estate</sp
 <details class="scripture-proofs" id="wlc-q20-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>e.</strong> Matt. 10:29–31; Gen. 45:7; Ps. 135:6, <strong>f.</strong> Rom. 11:36; Isa. 63:14, <strong>g.</strong> 2 Pet. 2:4; Heb. 2:16; John 8:44, <strong>h.</strong> Job 1:12; Matt. 8:31; Luke 10:17, <strong>i.</strong> 1 Tim. 5:21; Mark 8:38; Heb. 12:22; Ps. 103:20; Ps. 104:4, <strong>l.</strong> Heb. 1:14; 2 Kings 19:35, <strong>m.</strong> Gen. 2:8, 15–16, <strong>n.</strong> Gen. 1:28, <strong>o.</strong> Gen. 2:18; Matt. 19:3–9; Eph. 5:31, <strong>p.</strong> Gen. 1:26–29; Gen. 3:8, <strong>q.</strong> Gen. 2:3, <strong>r.</strong> Gen. 2:16–17; Gal. 3:12; Rom. 10:5, <strong>s.</strong> Gen. 2:9; Gen. 3:22–24</p></div>
+<p><strong>e.</strong> Matt. 10:29-31; Gen. 45:7; Ps. 135:6, <strong>f.</strong> Rom. 11:36; Isa. 63:14, <strong>g.</strong> 2 Pet. 2:4; Heb. 2:16; John 8:44, <strong>h.</strong> Job 1:12; Matt. 8:31; Luke 10:17, <strong>i.</strong> 1 Tim. 5:21; Mark 8:38; Heb. 12:22; Ps. 103:20; Ps. 104:4, <strong>l.</strong> Heb. 1:14; 2 Kings 19:35, <strong>m.</strong> Gen. 2:8, 15-16, <strong>n.</strong> Gen. 1:28, <strong>o.</strong> Gen. 2:18; Matt. 19:3-9; Eph. 5:31, <strong>p.</strong> Gen. 1:26-29; Gen. 3:8, <strong>q.</strong> Gen. 2:3, <strong>r.</strong> Gen. 2:16-17; Gal. 3:12; Rom. 10:5, <strong>s.</strong> Gen. 2:9; Gen. 3:22-24</p></div>
 </details>
 
 
@@ -253,7 +253,7 @@ Answer: The covenant being made with Adam as a public person, not for himself on
 <details class="scripture-proofs" id="wlc-q22-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>t.</strong> Gen. 2:17, <strong>u.</strong> Gen. 3:6–8, 13; 2 Cor. 11:3, <strong>w.</strong> Acts 17:26; Rom. 3:23, <strong>x.</strong> Gen. 2:16–17; Rom. 5:12–20</p></div>
+<p><strong>t.</strong> Gen. 2:17, <strong>u.</strong> Gen. 3:6-8, 13; 2 Cor. 11:3, <strong>w.</strong> Acts 17:26; Rom. 3:23, <strong>x.</strong> Gen. 2:16-17; Rom. 5:12-20</p></div>
 </details>
 
 
@@ -288,7 +288,7 @@ Answer: The sinfulness of that <span class="v-const">estate whereinto</span><spa
 <details class="scripture-proofs" id="wlc-q25-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Rom. 5:12, 19, <strong>y.</strong> Gen. 3:16–19; Rom. 5:12; Eph. 2:1; Rom. 3:16, 23, <strong>z.</strong> Lev. 5:17; 1 John 3:4; Gal. 3:10, 12</p></div>
+<p><strong>a.</strong> Rom. 5:12, 19, <strong>y.</strong> Gen. 3:16-19; Rom. 5:12; Eph. 2:1; Rom. 3:16, 23, <strong>z.</strong> Lev. 5:17; 1 John 3:4; Gal. 3:10, 12</p></div>
 </details>
 
 
@@ -311,7 +311,7 @@ Answer: The fall brought upon mankind the loss of communion with God, his disple
 <details class="scripture-proofs" id="wlc-q27-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>b.</strong> Rom. 3:10–12; Eph. 2:1–3; Rom. 5:6; Rom. 8:7–8; Gen. 6:5; Col. 3:10; Eph. 4:24, <strong>c.</strong> Ps. 53:1–3; Matt. 15:19; Rom. 3:10–18, 23; Gal. 5:19–21, <strong>d.</strong> Ps. 51:5; Job 14:4; John 3:6, <strong>e.</strong> Gen. 3:8, 10, 24; John 8:34, 42, 44; Eph. 2:12, <strong>f.</strong> Gen. 3:16–19; Job 5:7; Rom. 8:18–23, <strong>g.</strong> Eph. 2:2–3; John 3:36; Rom. 1:18</p></div>
+<p><strong>b.</strong> Rom. 3:10-12; Eph. 2:1-3; Rom. 5:6; Rom. 8:7-8; Gen. 6:5; Col. 3:10; Eph. 4:24, <strong>c.</strong> Ps. 53:1-3; Matt. 15:19; Rom. 3:10-18, 23; Gal. 5:19-21, <strong>d.</strong> Ps. 51:5; Job 14:4; John 3:6, <strong>e.</strong> Gen. 3:8, 10, 24; John 8:34, 42, 44; Eph. 2:12, <strong>f.</strong> Gen. 3:16-19; Job 5:7; Rom. 8:18-23, <strong>g.</strong> Eph. 2:2-3; John 3:36; Rom. 1:18</p></div>
 </details>
 
 
@@ -345,7 +345,7 @@ Answer: God <span class="v-const">doth</span><span class="v-modern">does</span> 
 <details class="scripture-proofs" id="wlc-q30-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>s.</strong> Rom. 6:21, 23, <strong>t.</strong> 2 Thess. 1:9; Mark 9:43–44, 46, 48; Luke 16:24, 26; Matt. 25:41, 46; Rev. 14:11; John 3:36, <strong>u.</strong> 1 Thess. 5:9, <strong>w.</strong> Gen. 3:17; Rom. 5:12, 15; Gal. 3:10, 12</p></div>
+<p><strong>s.</strong> Rom. 6:21, 23, <strong>t.</strong> 2 Thess. 1:9; Mark 9:43-44, 46, 48; Luke 16:24, 26; Matt. 25:41, 46; Rev. 14:11; John 3:36, <strong>u.</strong> 1 Thess. 5:9, <strong>w.</strong> Gen. 3:17; Rom. 5:12, 15; Gal. 3:10, 12</p></div>
 </details>
 
 
@@ -368,7 +368,7 @@ Answer: The grace of God is manifested in the second covenant, in that he freely
 <details class="scripture-proofs" id="wlc-q32-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> 1 John 5:11–12, <strong>b.</strong> John 3:16, 36; John 1:12, <strong>c.</strong> Isa. 59:21; Luke 11:13; John 14:16–20; 1 Cor. 12:13; Rom. 8:9, <strong>d.</strong> 2 Cor. 4:13; 1 Cor. 12:3, 9; Eph. 2:8–10; Acts 16:14; 2 Pet. 1:1, <strong>e.</strong> Gal. 5:22–23, <strong>f.</strong> Ezek. 36:27; Eph. 2:10, <strong>y.</strong> Gal. 3:16; Rom. 5:15; Isa. 53:10–11; Isa. 59:20–21, <strong>z.</strong> Gen. 3:15; Isa. 42:6; John 3:16; John 6:27; 1 Tim. 2:5</p></div>
+<p><strong>a.</strong> 1 John 5:11-12, <strong>b.</strong> John 3:16, 36; John 1:12, <strong>c.</strong> Isa. 59:21; Luke 11:13; John 14:16-20; 1 Cor. 12:13; Rom. 8:9, <strong>d.</strong> 2 Cor. 4:13; 1 Cor. 12:3, 9; Eph. 2:8-10; Acts 16:14; 2 Pet. 1:1, <strong>e.</strong> Gal. 5:22-23, <strong>f.</strong> Ezek. 36:27; Eph. 2:10, <strong>y.</strong> Gal. 3:16; Rom. 5:15; Isa. 53:10-11; Isa. 59:20-21, <strong>z.</strong> Gen. 3:15; Isa. 42:6; John 3:16; John 6:27; 1 Tim. 2:5</p></div>
 </details>
 
 
@@ -391,7 +391,7 @@ Answer: The covenant of grace was administered under the <span class="v-const">O
 <details class="scripture-proofs" id="wlc-q34-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>h.</strong> 2 Cor. 5:14–15, <strong>i.</strong> Eph. 2:10; 2 Cor. 3:6–9; Heb. 8:7–13, <strong>l.</strong> Rom. 15:8; Gen. 3:15, <strong>m.</strong> Acts 3:20, 24; Isa. 52:13–53:12, <strong>n.</strong> Heb. 10:1, <strong>o.</strong> Rom. 4:11</p></div>
+<p><strong>h.</strong> 2 Cor. 5:14-15, <strong>i.</strong> Eph. 2:10; 2 Cor. 3:6-9; Heb. 8:7-13, <strong>l.</strong> Rom. 15:8; Gen. 3:15, <strong>m.</strong> Acts 3:20, 24; Isa. 52:13-53:12, <strong>n.</strong> Heb. 10:1, <strong>o.</strong> Rom. 4:11</p></div>
 </details>
 
 
@@ -402,7 +402,7 @@ Answer: Under the <span class="v-const">New Testament,</span><span class="v-mode
 <details class="scripture-proofs" id="wlc-q35-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>p.</strong> 1 Cor. 5:7, <strong>q.</strong> Heb. 8:1–2; Heb. 11:13, <strong>r.</strong> Gal. 3:7–9, 14, <strong>s.</strong> Luke 24:47–48; Matt. 28:19–20, <strong>t.</strong> Matt. 28:19–20, <strong>u.</strong> Matt. 26:28; 1 Cor. 11:23–25</p></div>
+<p><strong>p.</strong> 1 Cor. 5:7, <strong>q.</strong> Heb. 8:1-2; Heb. 11:13, <strong>r.</strong> Gal. 3:7-9, 14, <strong>s.</strong> Luke 24:47-48; Matt. 28:19-20, <strong>t.</strong> Matt. 28:19-20, <strong>u.</strong> Matt. 26:28; 1 Cor. 11:23-25</p></div>
 </details>
 
 
@@ -413,7 +413,7 @@ Answer: The only mediator of the covenant of grace is the Lord Jesus Christ,<sup
 <details class="scripture-proofs" id="wlc-q36-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>w.</strong> Rom. 1:16; 2 Cor. 3:6–9; Heb. 8:6, 10–11; Matt. 28:19; Eph. 3:1–12, <strong>x.</strong> 1 Tim. 2:5; John 14:6; Acts 4:12, <strong>y.</strong> John 1:1, 14, 18; John 10:30; Phil. 2:6; Ps. 2:7; Matt. 3:17; Matt. 17:5, <strong>z.</strong> Gal. 4:4; Matt. 1:23; John 1:14</p></div>
+<p><strong>w.</strong> Rom. 1:16; 2 Cor. 3:6-9; Heb. 8:6, 10-11; Matt. 28:19; Eph. 3:1-12, <strong>x.</strong> 1 Tim. 2:5; John 14:6; Acts 4:12, <strong>y.</strong> John 1:1, 14, 18; John 10:30; Phil. 2:6; Ps. 2:7; Matt. 3:17; Matt. 17:5, <strong>z.</strong> Gal. 4:4; Matt. 1:23; John 1:14</p></div>
 </details>
 
 
@@ -424,7 +424,7 @@ Answer: Christ the Son of God became man, by taking to himself a true body, and 
 <details class="scripture-proofs" id="wlc-q37-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Luke 1:35; Acts 1:11; Rom. 9:5; Col. 2:9; Heb. 7:24–25; Heb. 13:8; Phil. 2:5–11, <strong>b.</strong> John 1:14; Matt. 26:38; Phil. 2:7; Heb. 2:14–17; Luke 2:40, 52; John 11:33, <strong>c.</strong> Luke 1:27, 31, 35; Gal. 4:4, <strong>d.</strong> Heb. 4:15; Heb. 7:26; 2 Cor. 5:21; 1 John 3:5</p></div>
+<p><strong>a.</strong> Luke 1:35; Acts 1:11; Rom. 9:5; Col. 2:9; Heb. 7:24-25; Heb. 13:8; Phil. 2:5-11, <strong>b.</strong> John 1:14; Matt. 26:38; Phil. 2:7; Heb. 2:14-17; Luke 2:40, 52; John 11:33, <strong>c.</strong> Luke 1:27, 31, 35; Gal. 4:4, <strong>d.</strong> Heb. 4:15; Heb. 7:26; 2 Cor. 5:21; 1 John 3:5</p></div>
 </details>
 
 
@@ -435,7 +435,7 @@ Answer: It was requisite that the <span class="v-const">mediator</span><span cla
 <details class="scripture-proofs" id="wlc-q38-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>e.</strong> Acts 2:24–25; Rom. 1:4; Rom. 4:25; Heb. 9:14, <strong>f.</strong> Acts 20:28; Heb. 9:14; Heb. 7:25–28, <strong>g.</strong> Rom. 3:24–26, <strong>h.</strong> Eph. 1:6; Matt. 3:17, <strong>i.</strong> Gal. 4:6; John 15:26; John 16:7, <strong>l.</strong> Luke 1:68–69, 71, 74</p></div>
+<p><strong>e.</strong> Acts 2:24-25; Rom. 1:4; Rom. 4:25; Heb. 9:14, <strong>f.</strong> Acts 20:28; Heb. 9:14; Heb. 7:25-28, <strong>g.</strong> Rom. 3:24-26, <strong>h.</strong> Eph. 1:6; Matt. 3:17, <strong>i.</strong> Gal. 4:6; John 15:26; John 16:7, <strong>l.</strong> Luke 1:68-69, 71, 74</p></div>
 </details>
 
 
@@ -446,7 +446,7 @@ Answer: It was requisite that the <span class="v-const">mediator</span><span cla
 <details class="scripture-proofs" id="wlc-q39-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>m.</strong> Heb. 5:8–9; Heb. 9:11–15, <strong>n.</strong> Heb. 2:16; 2 Pet. 1:4, <strong>o.</strong> Gal. 4:4; Matt. 5:17; Rom. 5:19; Phil. 2:8, <strong>p.</strong> Heb. 2:14; Heb. 7:24–25, <strong>q.</strong> Heb. 4:15, <strong>r.</strong> Gal. 4:5, <strong>s.</strong> Heb. 4:16</p></div>
+<p><strong>m.</strong> Heb. 5:8-9; Heb. 9:11-15, <strong>n.</strong> Heb. 2:16; 2 Pet. 1:4, <strong>o.</strong> Gal. 4:4; Matt. 5:17; Rom. 5:19; Phil. 2:8, <strong>p.</strong> Heb. 2:14; Heb. 7:24-25, <strong>q.</strong> Heb. 4:15, <strong>r.</strong> Gal. 4:5, <strong>s.</strong> Heb. 4:16</p></div>
 </details>
 
 
@@ -481,7 +481,7 @@ Answer: Our <span class="v-const">mediator</span><span class="v-modern">Mediator
 <details class="scripture-proofs" id="wlc-q42-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>t.</strong> Matt. 1:21, 23; Matt. 3:17; Heb. 9:14, <strong>u.</strong> 1 Pet. 2:6, <strong>w.</strong> Matt. 1:21, <strong>x.</strong> Matt. 3:16; Acts 10:37–38; John 3:34; Ps. 45:7, <strong>y.</strong> John 6:27; Matt. 28:18–20; Rom. 1:3–4</p></div>
+<p><strong>t.</strong> Matt. 1:21, 23; Matt. 3:17; Heb. 9:14, <strong>u.</strong> 1 Pet. 2:6, <strong>w.</strong> Matt. 1:21, <strong>x.</strong> Matt. 3:16; Acts 10:37-38; John 3:34; Ps. 45:7, <strong>y.</strong> John 6:27; Matt. 28:18-20; Rom. 1:3-4</p></div>
 </details>
 
 
@@ -492,7 +492,7 @@ Answer: Christ <span class="v-const">executeth</span><span class="v-modern">exec
 <details class="scripture-proofs" id="wlc-q43-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Heb. 5:5–7; Heb. 4:14–15, <strong>b.</strong> Ps. 2:6; Luke 1:32–34; John 18:37; Matt. 21:5; Isa. 9:6–7; Phil. 2:8–11, <strong>z.</strong> Acts 3:21–22; Luke 4:18, 21; Heb. 1:1–2; Deut. 18:18</p></div>
+<p><strong>a.</strong> Heb. 5:5-7; Heb. 4:14-15, <strong>b.</strong> Ps. 2:6; Luke 1:32-34; John 18:37; Matt. 21:5; Isa. 9:6-7; Phil. 2:8-11, <strong>z.</strong> Acts 3:21-22; Luke 4:18, 21; Heb. 1:1-2; Deut. 18:18</p></div>
 </details>
 
 
@@ -503,7 +503,7 @@ Answer: Christ <span class="v-const">executeth</span><span class="v-modern">exec
 <details class="scripture-proofs" id="wlc-q44-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>c.</strong> John 1:18, <strong>d.</strong> 1 Pet. 1:10–12, <strong>e.</strong> Heb. 1:1–2, <strong>f.</strong> John 15:15, <strong>g.</strong> Acts 20:32; Eph. 4:11–13; John 20:31, <strong>h.</strong> Heb. 9:14, 28; Heb. 10:12, <strong>i.</strong> Heb. 2:17</p></div>
+<p><strong>c.</strong> John 1:18, <strong>d.</strong> 1 Pet. 1:10-12, <strong>e.</strong> Heb. 1:1-2, <strong>f.</strong> John 15:15, <strong>g.</strong> Acts 20:32; Eph. 4:11-13; John 20:31, <strong>h.</strong> Heb. 9:14, 28; Heb. 10:12, <strong>i.</strong> Heb. 2:17</p></div>
 </details>
 
 
@@ -514,7 +514,7 @@ Answer: Christ <span class="v-const">executeth</span><span class="v-modern">exec
 <details class="scripture-proofs" id="wlc-q45-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Acts 15:14–16; Gen. 49:10; Ps. 110:3; John 17:2, <strong>m.</strong> Eph. 4:11–12; 1 Cor. 12:28, <strong>n.</strong> Isa. 33:22, <strong>o.</strong> Matt. 18:17–18, <strong>p.</strong> Acts 5:31, <strong>q.</strong> Rev. 22:12; Rev. 2:10</p></div>
+<p><strong>l.</strong> Acts 15:14-16; Gen. 49:10; Ps. 110:3; John 17:2, <strong>m.</strong> Eph. 4:11-12; 1 Cor. 12:28, <strong>n.</strong> Isa. 33:22, <strong>o.</strong> Matt. 18:17-18, <strong>p.</strong> Acts 5:31, <strong>q.</strong> Rev. 22:12; Rev. 2:10</p></div>
 </details>
 
 
@@ -525,7 +525,7 @@ Answer: The <span class="v-const">estate</span><span class="v-modern">state</spa
 <details class="scripture-proofs" id="wlc-q46-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Luke 2:7, <strong>b.</strong> Gal. 4:4; 2 Cor. 8:9; Luke 9:58, <strong>r.</strong> Rev. 3:19, <strong>s.</strong> Isa. 63:9, <strong>t.</strong> 1 Cor. 15:25; Ps. 110:1–2, <strong>u.</strong> Rom. 14:10–11, <strong>w.</strong> Rom. 8:28, <strong>x.</strong> 2 Thess. 1:8–9; Ps. 2:8–9, <strong>y.</strong> Phil. 2:6–8, <strong>z.</strong> Luke 1:31</p></div>
+<p><strong>a.</strong> Luke 2:7, <strong>b.</strong> Gal. 4:4; 2 Cor. 8:9; Luke 9:58, <strong>r.</strong> Rev. 3:19, <strong>s.</strong> Isa. 63:9, <strong>t.</strong> 1 Cor. 15:25; Ps. 110:1-2, <strong>u.</strong> Rom. 14:10-11, <strong>w.</strong> Rom. 8:28, <strong>x.</strong> 2 Thess. 1:8-9; Ps. 2:8-9, <strong>y.</strong> Phil. 2:6-8, <strong>z.</strong> Luke 1:31</p></div>
 </details>
 
 
@@ -548,7 +548,7 @@ Answer: Christ humbled himself in his life, by subjecting himself to the law, wh
 <details class="scripture-proofs" id="wlc-q48-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>c.</strong> Ps. 22:1; Matt. 27:46; Isa. 53:10; 1 John 2:2; Phil. 2:8, <strong>d.</strong> Matt. 12:40; 1 Cor. 15:3–4, <strong>e.</strong> Acts 2:24–27, 31, <strong>f.</strong> John 1:14, 18; Gal. 4:4; Luke 2:7</p></div>
+<p><strong>c.</strong> Ps. 22:1; Matt. 27:46; Isa. 53:10; 1 John 2:2; Phil. 2:8, <strong>d.</strong> Matt. 12:40; 1 Cor. 15:3-4, <strong>e.</strong> Acts 2:24-27, 31, <strong>f.</strong> John 1:14, 18; Gal. 4:4; Luke 2:7</p></div>
 </details>
 
 
@@ -559,7 +559,7 @@ Answer: Christ humbled himself in his death, in that having been betrayed by Jud
 <details class="scripture-proofs" id="wlc-q49-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>g.</strong> Gal. 4:4, <strong>h.</strong> Matt. 5:17; Rom. 5:19, <strong>i.</strong> Ps. 22:6; Isa. 53:2–3; Heb. 12:2–3; Matt. 4:1–11; Luke 4:13, <strong>l.</strong> Heb. 2:17–18; Heb. 4:15; Isa. 52:13–14, <strong>m.</strong> Matt. 27:4, <strong>n.</strong> Matt. 26:56, <strong>o.</strong> Isa. 53:2–3</p></div>
+<p><strong>g.</strong> Gal. 4:4, <strong>h.</strong> Matt. 5:17; Rom. 5:19, <strong>i.</strong> Ps. 22:6; Isa. 53:2-3; Heb. 12:2-3; Matt. 4:1-11; Luke 4:13, <strong>l.</strong> Heb. 2:17-18; Heb. 4:15; Isa. 52:13-14, <strong>m.</strong> Matt. 27:4, <strong>n.</strong> Matt. 26:56, <strong>o.</strong> Isa. 53:2-3</p></div>
 </details>
 
 
@@ -570,7 +570,7 @@ Answer: Christ's humiliation after his death consisted in his being buried,<sup 
 <details class="scripture-proofs" id="wlc-q50-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>p.</strong> Matt. 27:26–50; John 19:34; Luke 22:63–64, <strong>q.</strong> Luke 22:44; Matt. 27:46, <strong>r.</strong> Isa. 53:10; Matt. 20:28; Mark 10:45, <strong>s.</strong> Phil. 2:8; Heb. 12:2; Gal. 3:13, <strong>t.</strong> 1 Cor. 15:3–4, <strong>u.</strong> Ps. 16:10; Acts 2:24–27, 31; Rom. 6:9; Matt. 12:40</p></div>
+<p><strong>p.</strong> Matt. 27:26-50; John 19:34; Luke 22:63-64, <strong>q.</strong> Luke 22:44; Matt. 27:46, <strong>r.</strong> Isa. 53:10; Matt. 20:28; Mark 10:45, <strong>s.</strong> Phil. 2:8; Heb. 12:2; Gal. 3:13, <strong>t.</strong> 1 Cor. 15:3-4, <strong>u.</strong> Ps. 16:10; Acts 2:24-27, 31; Rom. 6:9; Matt. 12:40</p></div>
 </details>
 
 
@@ -593,7 +593,7 @@ Answer: Christ was exalted in his resurrection, in that, not having seen corrupt
 <details class="scripture-proofs" id="wlc-q52-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Acts 2:24, 27, <strong>b.</strong> Luke 24:39, <strong>c.</strong> Rom. 6:9; Rev. 1:18, <strong>d.</strong> John 10:18, <strong>e.</strong> Rom. 1:4, <strong>f.</strong> Rom. 8:34; Rom. 3:25–26; Heb. 9:13–14, <strong>g.</strong> Heb. 2:14, <strong>h.</strong> Rom. 14:9, <strong>i.</strong> 1 Cor. 15:21–22; Isa. 53:10–11; Eph. 1:20–23; Col. 1:18, <strong>l.</strong> Rom. 4:25, <strong>m.</strong> Eph. 2:1, 5–6; Col. 2:12, <strong>w.</strong> 1 Cor. 15:4, <strong>x.</strong> Ps. 68:18; Acts 1:11; Eph. 4:8, <strong>y.</strong> Eph. 1:20; Ps. 110:1; Acts 2:33–34; Heb. 1:3, <strong>z.</strong> Acts 1:11; Acts 17:31; Matt. 16:27</p></div>
+<p><strong>a.</strong> Acts 2:24, 27, <strong>b.</strong> Luke 24:39, <strong>c.</strong> Rom. 6:9; Rev. 1:18, <strong>d.</strong> John 10:18, <strong>e.</strong> Rom. 1:4, <strong>f.</strong> Rom. 8:34; Rom. 3:25-26; Heb. 9:13-14, <strong>g.</strong> Heb. 2:14, <strong>h.</strong> Rom. 14:9, <strong>i.</strong> 1 Cor. 15:21-22; Isa. 53:10-11; Eph. 1:20-23; Col. 1:18, <strong>l.</strong> Rom. 4:25, <strong>m.</strong> Eph. 2:1, 5-6; Col. 2:12, <strong>w.</strong> 1 Cor. 15:4, <strong>x.</strong> Ps. 68:18; Acts 1:11; Eph. 4:8, <strong>y.</strong> Eph. 1:20; Ps. 110:1; Acts 2:33-34; Heb. 1:3, <strong>z.</strong> Acts 1:11; Acts 17:31; Matt. 16:27</p></div>
 </details>
 
 
@@ -604,7 +604,7 @@ Answer: Christ was exalted in his ascension, in that having after his resurrecti
 <details class="scripture-proofs" id="wlc-q53-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>n.</strong> 1 Cor. 15:25–27; Ps. 2:7–9, <strong>o.</strong> 1 Cor. 15:20; 1 Thess. 4:14, <strong>p.</strong> Acts 1:2–3, <strong>q.</strong> Matt. 28:19–20, <strong>r.</strong> John 20:17; Heb. 6:20, <strong>s.</strong> Eph. 4:8, <strong>t.</strong> Acts 1:9–11; Eph. 4:7–8</p></div>
+<p><strong>n.</strong> 1 Cor. 15:25-27; Ps. 2:7-9, <strong>o.</strong> 1 Cor. 15:20; 1 Thess. 4:14, <strong>p.</strong> Acts 1:2-3, <strong>q.</strong> Matt. 28:19-20, <strong>r.</strong> John 20:17; Heb. 6:20, <strong>s.</strong> Eph. 4:8, <strong>t.</strong> Acts 1:9-11; Eph. 4:7-8</p></div>
 </details>
 
 
@@ -615,7 +615,7 @@ Answer: Christ is exalted in his sitting at the right hand of God, in that as Go
 <details class="scripture-proofs" id="wlc-q54-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> John 17:5, <strong>b.</strong> Dan. 7:13–14; Eph. 1:22; 1 Pet. 3:22, <strong>c.</strong> Eph. 4:10–12; Ps. 110:1, <strong>u.</strong> Col. 3:1–2, <strong>w.</strong> John 14:3, <strong>x.</strong> Acts 3:21, <strong>y.</strong> Phil. 2:9, <strong>z.</strong> Acts 2:28; Ps. 16:11</p></div>
+<p><strong>a.</strong> John 17:5, <strong>b.</strong> Dan. 7:13-14; Eph. 1:22; 1 Pet. 3:22, <strong>c.</strong> Eph. 4:10-12; Ps. 110:1, <strong>u.</strong> Col. 3:1-2, <strong>w.</strong> John 14:3, <strong>x.</strong> Acts 3:21, <strong>y.</strong> Phil. 2:9, <strong>z.</strong> Acts 2:28; Ps. 16:11</p></div>
 </details>
 
 
@@ -626,7 +626,7 @@ Answer: Christ <span class="v-const">maketh</span><span class="v-modern">makes</
 <details class="scripture-proofs" id="wlc-q55-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>d.</strong> Rom. 8:34; 1 John 2:1; Heb. 7:25, <strong>e.</strong> Heb. 9:12, 24, <strong>f.</strong> Isa. 53:12; Heb. 1:3, <strong>g.</strong> John 3:16; John 17:9, 20, 24, <strong>h.</strong> Rom. 8:33–34, <strong>i.</strong> Rom. 5:1–2; 1 John 2:1–2</p></div>
+<p><strong>d.</strong> Rom. 8:34; 1 John 2:1; Heb. 7:25, <strong>e.</strong> Heb. 9:12, 24, <strong>f.</strong> Isa. 53:12; Heb. 1:3, <strong>g.</strong> John 3:16; John 17:9, 20, 24, <strong>h.</strong> Rom. 8:33-34, <strong>i.</strong> Rom. 5:1-2; 1 John 2:1-2</p></div>
 </details>
 
 
@@ -637,7 +637,7 @@ Answer: Christ is to be exalted in his coming again to judge the world, in that 
 <details class="scripture-proofs" id="wlc-q56-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Eph. 1:6, <strong>m.</strong> 1 Pet. 2:5, <strong>n.</strong> Acts 3:14–15, <strong>o.</strong> Matt. 24:30; 2 Thess. 1:9–10, <strong>p.</strong> Luke 9:26; Matt. 25:31, <strong>q.</strong> 1 Thess. 4:16, <strong>r.</strong> Acts 17:31; 2 Thess. 1:6–8</p></div>
+<p><strong>l.</strong> Eph. 1:6, <strong>m.</strong> 1 Pet. 2:5, <strong>n.</strong> Acts 3:14-15, <strong>o.</strong> Matt. 24:30; 2 Thess. 1:9-10, <strong>p.</strong> Luke 9:26; Matt. 25:31, <strong>q.</strong> 1 Thess. 4:16, <strong>r.</strong> Acts 17:31; 2 Thess. 1:6-8</p></div>
 </details>
 
 
@@ -672,7 +672,7 @@ Answer: Redemption is certainly applied, and effectually communicated, to all th
 <details class="scripture-proofs" id="wlc-q59-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>s.</strong> 1 Tim. 2:5–6; Heb. 9:12; Eph. 1:7, <strong>t.</strong> 2 Cor. 1:20; Eph. 1:3–6; 2 Pet. 1:3–4, <strong>u.</strong> John 1:11–12, <strong>w.</strong> John 16:14–15; John 3:3–8, <strong>x.</strong> Eph. 1:13–14</p></div>
+<p><strong>s.</strong> 1 Tim. 2:5-6; Heb. 9:12; Eph. 1:7, <strong>t.</strong> 2 Cor. 1:20; Eph. 1:3-6; 2 Pet. 1:3-4, <strong>u.</strong> John 1:11-12, <strong>w.</strong> John 16:14-15; John 3:3-8, <strong>x.</strong> Eph. 1:13-14</p></div>
 </details>
 
 
@@ -683,7 +683,7 @@ Answer: <span class="v-const">They</span><span class="v-modern">Those</span> who
 <details class="scripture-proofs" id="wlc-q60-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> 2 Thess. 1:8–9; Eph. 2:12; John 1:10–12, <strong>b.</strong> John 8:24; John 3:18, <strong>c.</strong> 1 Cor. 1:20–24, <strong>y.</strong> Rom. 10:17; 1 Cor. 2:12–16; Eph. 2:8; Rom. 8:9, 14, <strong>z.</strong> Rom. 10:14</p></div>
+<p><strong>a.</strong> 2 Thess. 1:8-9; Eph. 2:12; John 1:10-12, <strong>b.</strong> John 8:24; John 3:18, <strong>c.</strong> 1 Cor. 1:20-24, <strong>y.</strong> Rom. 10:17; 1 Cor. 2:12-16; Eph. 2:8; Rom. 8:9, 14, <strong>z.</strong> Rom. 10:14</p></div>
 </details>
 
 
@@ -694,7 +694,7 @@ Answer: All that hear the gospel, and live in the visible church, are not saved;
 <details class="scripture-proofs" id="wlc-q61-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>d.</strong> John 4:22; Rom. 9:31–32; Phil. 3:4–9, <strong>e.</strong> Acts 4:12, <strong>f.</strong> Eph. 5:23, <strong>g.</strong> John 12:38–40; Rom. 9:6; Matt. 22:14; Matt. 7:21; Rom. 11:7; 1 Cor. 10:2–5</p></div>
+<p><strong>d.</strong> John 4:22; Rom. 9:31-32; Phil. 3:4-9, <strong>e.</strong> Acts 4:12, <strong>f.</strong> Eph. 5:23, <strong>g.</strong> John 12:38-40; Rom. 9:6; Matt. 22:14; Matt. 7:21; Rom. 11:7; 1 Cor. 10:2-5</p></div>
 </details>
 
 
@@ -717,7 +717,7 @@ Answer: The visible church <span class="v-const">hath</span><span class="v-moder
 <details class="scripture-proofs" id="wlc-q63-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>h.</strong> 1 Cor. 1:2; 1 Cor. 12:13; Rom. 15:9–12; Rev. 7:9; Ps. 2:8; Ps. 22:27–31; Ps. 45:17; Matt. 28:19–20; Isa. 59:21, <strong>i.</strong> 1 Cor. 7:14; Acts 2:39; Rom. 11:16; Gen. 17:7, <strong>l.</strong> Ps. 115:1–2, 9; Isa. 31:4–5; Zech. 12:2–4, 8–9; Matt. 16:18, <strong>m.</strong> Acts 2:39, 42; Matt. 28:19–20; 1 Cor. 12:12–13</p></div>
+<p><strong>h.</strong> 1 Cor. 1:2; 1 Cor. 12:13; Rom. 15:9-12; Rev. 7:9; Ps. 2:8; Ps. 22:27-31; Ps. 45:17; Matt. 28:19-20; Isa. 59:21, <strong>i.</strong> 1 Cor. 7:14; Acts 2:39; Rom. 11:16; Gen. 17:7, <strong>l.</strong> Ps. 115:1-2, 9; Isa. 31:4-5; Zech. 12:2-4, 8-9; Matt. 16:18, <strong>m.</strong> Acts 2:39, 42; Matt. 28:19-20; 1 Cor. 12:12-13</p></div>
 </details>
 
 
@@ -740,7 +740,7 @@ Answer: The members of the invisible church by Christ enjoy union and communion 
 <details class="scripture-proofs" id="wlc-q65-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>n.</strong> Ps. 147:19–20; Rom. 9:4; Eph. 4:11–12; Acts 22:16; Acts 2:21; Joel 2:32; Rom. 10:10–13, 17, <strong>o.</strong> Matt. 11:28–29; John 6:37, <strong>p.</strong> Eph. 1:10; Eph. 1:22–23; John 10:16; John 11:52; Eph. 5:23, 27, 32, <strong>q.</strong> John 17:21</p></div>
+<p><strong>n.</strong> Ps. 147:19-20; Rom. 9:4; Eph. 4:11-12; Acts 22:16; Acts 2:21; Joel 2:32; Rom. 10:10-13, 17, <strong>o.</strong> Matt. 11:28-29; John 6:37, <strong>p.</strong> Eph. 1:10; Eph. 1:22-23; John 10:16; John 11:52; Eph. 5:23, 27, 32, <strong>q.</strong> John 17:21</p></div>
 </details>
 
 
@@ -763,7 +763,7 @@ Answer: Effectual calling is the work of God's almighty power and grace,<sup cla
 <details class="scripture-proofs" id="wlc-q67-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>r.</strong> Eph. 2:6–7, <strong>s.</strong> Eph. 1:22; 1 Cor. 6:17; John 10:28; Eph. 5:23, 30; John 15:5; Eph. 3:17, <strong>t.</strong> 1 Pet. 5:10; 1 Cor. 1:9, <strong>u.</strong> Ezek. 37:9, 14, <strong>w.</strong> Eph. 2:4–5, 7–9; Rom. 9:11; Deut. 9:5, <strong>x.</strong> John 3:5; 2 Cor. 5:20; 2 Cor. 6:1–2; John 6:44–45; Acts 16:14</p></div>
+<p><strong>r.</strong> Eph. 2:6-7, <strong>s.</strong> Eph. 1:22; 1 Cor. 6:17; John 10:28; Eph. 5:23, 30; John 15:5; Eph. 3:17, <strong>t.</strong> 1 Pet. 5:10; 1 Cor. 1:9, <strong>u.</strong> Ezek. 37:9, 14, <strong>w.</strong> Eph. 2:4-5, 7-9; Rom. 9:11; Deut. 9:5, <strong>x.</strong> John 3:5; 2 Cor. 5:20; 2 Cor. 6:1-2; John 6:44-45; Acts 16:14</p></div>
 </details>
 
 
@@ -774,7 +774,7 @@ Answer: All the elect, and they only, are effectually called;<sup class="proof-m
 <details class="scripture-proofs" id="wlc-q68-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Eph. 2:5; Phil. 2:13; Deut. 30:6; Isa. 45:22; Matt. 11:28–30; Rev. 22:17, <strong>b.</strong> Acts 13:48, <strong>y.</strong> Acts 26:18; 1 Cor. 2:10, 12; 2 Cor. 4:6; Eph. 1:17–18, <strong>z.</strong> Ezek. 11:19; Ezek. 36:26–27; John 6:45</p></div>
+<p><strong>a.</strong> Eph. 2:5; Phil. 2:13; Deut. 30:6; Isa. 45:22; Matt. 11:28-30; Rev. 22:17, <strong>b.</strong> Acts 13:48, <strong>y.</strong> Acts 26:18; 1 Cor. 2:10, 12; 2 Cor. 4:6; Eph. 1:17-18, <strong>z.</strong> Ezek. 11:19; Ezek. 36:26-27; John 6:45</p></div>
 </details>
 
 
@@ -785,7 +785,7 @@ Answer: The communion in grace <span class="v-const">which</span><span class="v-
 <details class="scripture-proofs" id="wlc-q69-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>c.</strong> Matt. 22:14; Acts 8:13, 20–21, <strong>d.</strong> Matt. 7:22; Matt. 13:20–21; Heb. 6:4–6, <strong>e.</strong> John 12:38–40; Acts 28:25–27; John 6:64–65; Ps. 81:11–12; Heb. 10:29</p></div>
+<p><strong>c.</strong> Matt. 22:14; Acts 8:13, 20-21, <strong>d.</strong> Matt. 7:22; Matt. 13:20-21; Heb. 6:4-6, <strong>e.</strong> John 12:38-40; Acts 28:25-27; John 6:64-65; Ps. 81:11-12; Heb. 10:29</p></div>
 </details>
 
 
@@ -796,7 +796,7 @@ Answer: Justification is an act of God's free grace <span class="v-const">unto</
 <details class="scripture-proofs" id="wlc-q70-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>f.</strong> Rom. 8:30, <strong>g.</strong> Eph. 1:5, <strong>h.</strong> 1 Cor. 1:30; 1 Cor. 6:11, <strong>i.</strong> Rom. 3:22, 24–25; Rom. 4:5; Jer. 23:6; Rom. 4:6–8; 2 Cor. 5:19, 21; Rom. 3:22, 24–25, 27–28</p></div>
+<p><strong>f.</strong> Rom. 8:30, <strong>g.</strong> Eph. 1:5, <strong>h.</strong> 1 Cor. 1:30; 1 Cor. 6:11, <strong>i.</strong> Rom. 3:22, 24-25; Rom. 4:5; Jer. 23:6; Rom. 4:6-8; 2 Cor. 5:19, 21; Rom. 3:22, 24-25, 27-28</p></div>
 </details>
 
 
@@ -807,7 +807,7 @@ Answer: Although Christ, by his obedience and death, <span class="v-const">did m
 <details class="scripture-proofs" id="wlc-q71-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>m.</strong> Rom. 4:6–8, 11; Rom. 5:17–19, <strong>n.</strong> Acts 10:43; Gal. 2:16; Phil. 3:9, <strong>o.</strong> Rom. 5:8–10, 19, <strong>p.</strong> 1 Tim. 2:5–6; Heb. 10:10; Matt. 20:28; Dan. 9:24, 26</p></div>
+<p><strong>m.</strong> Rom. 4:6-8, 11; Rom. 5:17-19, <strong>n.</strong> Acts 10:43; Gal. 2:16; Phil. 3:9, <strong>o.</strong> Rom. 5:8-10, 19, <strong>p.</strong> 1 Tim. 2:5-6; Heb. 10:10; Matt. 20:28; Dan. 9:24, 26</p></div>
 </details>
 
 
@@ -818,7 +818,7 @@ Answer: Justifying faith is a saving grace,<sup class="proof-marker">u</sup> wro
 <details class="scripture-proofs" id="wlc-q72-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> John 1:12; Acts 16:31; Acts 10:43, <strong>q.</strong> 2 Cor. 5:21; Rom. 4:6, 11, <strong>r.</strong> Rom. 3:24–25, <strong>s.</strong> Eph. 2:8, <strong>t.</strong> Eph. 1:7; Rom. 3:24–25, <strong>u.</strong> Heb. 10:39, <strong>w.</strong> 2 Cor. 4:13; Eph. 1:17–19; 1 Cor. 12:3; 1 Pet. 1:2, <strong>x.</strong> Rom. 10:14–17; 1 Cor. 1:21, <strong>y.</strong> Acts 2:37; Acts 16:30; John 16:8–9; Rom. 6:6; Eph. 2:1; Acts 4:12, <strong>z.</strong> Eph. 1:13; Heb. 11:13</p></div>
+<p><strong>a.</strong> John 1:12; Acts 16:31; Acts 10:43, <strong>q.</strong> 2 Cor. 5:21; Rom. 4:6, 11, <strong>r.</strong> Rom. 3:24-25, <strong>s.</strong> Eph. 2:8, <strong>t.</strong> Eph. 1:7; Rom. 3:24-25, <strong>u.</strong> Heb. 10:39, <strong>w.</strong> 2 Cor. 4:13; Eph. 1:17-19; 1 Cor. 12:3; 1 Pet. 1:2, <strong>x.</strong> Rom. 10:14-17; 1 Cor. 1:21, <strong>y.</strong> Acts 2:37; Acts 16:30; John 16:8-9; Rom. 6:6; Eph. 2:1; Acts 4:12, <strong>z.</strong> Eph. 1:13; Heb. 11:13</p></div>
 </details>
 
 
@@ -841,7 +841,7 @@ Answer: Adoption is an act of the free grace of God,<sup class="proof-marker">f<
 <details class="scripture-proofs" id="wlc-q74-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>b.</strong> Phil. 3:9; Acts 15:11, <strong>c.</strong> Gal. 3:11; Rom. 3:28, <strong>d.</strong> Rom. 4:5; Rom. 10:10, <strong>e.</strong> John 1:12; Phil. 3:9; Gal. 2:16, <strong>f.</strong> 1 John 3:1, <strong>g.</strong> Eph. 1:5; Gal. 4:4–5, <strong>h.</strong> John 1:12; Rom. 8:15–16</p></div>
+<p><strong>b.</strong> Phil. 3:9; Acts 15:11, <strong>c.</strong> Gal. 3:11; Rom. 3:28, <strong>d.</strong> Rom. 4:5; Rom. 10:10, <strong>e.</strong> John 1:12; Phil. 3:9; Gal. 2:16, <strong>f.</strong> 1 John 3:1, <strong>g.</strong> Eph. 1:5; Gal. 4:4-5, <strong>h.</strong> John 1:12; Rom. 8:15-16</p></div>
 </details>
 
 
@@ -852,7 +852,7 @@ Answer: Sanctification is a work of God's grace, <span cl<span class="v-const">a
 <details class="scripture-proofs" id="wlc-q75-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>i.</strong> Num. 6:24–27; Amos 9:12; 2 Cor. 6:18; Rev. 3:12; Gal. 4:6, <strong>l.</strong> Ps. 103:13; Prov. 14:26; Matt. 6:32; Heb. 12:5–7, 11, <strong>m.</strong> Heb. 6:12; Rom. 8:17; 1 Pet. 1:3–4, <strong>n.</strong> Ezek. 36:27; Phil. 2:13; 2 Thess. 2:13, <strong>o.</strong> Rom. 6:4–6; Col. 3:1–3; Phil. 3:10, <strong>p.</strong> 2 Cor. 5:17; Eph. 4:23–24; 1 Thess. 5:23, <strong>q.</strong> Acts 11:18; 1 John 3:9, <strong>r.</strong> Heb. 6:11–12; Eph. 3:16–19; Col. 1:10–11, <strong>s.</strong> Ezek. 36:25–27</p></div>
+<p><strong>i.</strong> Num. 6:24-27; Amos 9:12; 2 Cor. 6:18; Rev. 3:12; Gal. 4:6, <strong>l.</strong> Ps. 103:13; Prov. 14:26; Matt. 6:32; Heb. 12:5-7, 11, <strong>m.</strong> Heb. 6:12; Rom. 8:17; 1 Pet. 1:3-4, <strong>n.</strong> Ezek. 36:27; Phil. 2:13; 2 Thess. 2:13, <strong>o.</strong> Rom. 6:4-6; Col. 3:1-3; Phil. 3:10, <strong>p.</strong> 2 Cor. 5:17; Eph. 4:23-24; 1 Thess. 5:23, <strong>q.</strong> Acts 11:18; 1 John 3:9, <strong>r.</strong> Heb. 6:11-12; Eph. 3:16-19; Col. 1:10-11, <strong>s.</strong> Ezek. 36:25-27</p></div>
 </details>
 
 
@@ -863,7 +863,7 @@ Answer: Repentance unto life is a saving grace,<sup cl<span class="v-const">as</
 <details class="scripture-proofs" id="wlc-q76-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Jer. 31:18–19; Ps. 32:5, <strong>b.</strong> 2 Cor. 7:11, <strong>c.</strong> Luke 1:16–17; 1 Thess. 1:9, <strong>t.</strong> 2 Tim. 2:25; Acts 11:18, <strong>u.</strong> Zech. 12:10, <strong>w.</strong> Acts 11:18, 20–21, <strong>x.</strong> Ezek. 18:28, 30, 32; Luke 15:17–18; Hos. 2:6–7, <strong>y.</strong> Ezek. 36:31; Isa. 30:22; Phil. 3:7–8, <strong>z.</strong> Joel 2:12–13; Ps. 51:1–4; Luke 15:7, 10; Acts 2:37</p></div>
+<p><strong>a.</strong> Jer. 31:18-19; Ps. 32:5, <strong>b.</strong> 2 Cor. 7:11, <strong>c.</strong> Luke 1:16-17; 1 Thess. 1:9, <strong>t.</strong> 2 Tim. 2:25; Acts 11:18, <strong>u.</strong> Zech. 12:10, <strong>w.</strong> Acts 11:18, 20-21, <strong>x.</strong> Ezek. 18:28, 30, 32; Luke 15:17-18; Hos. 2:6-7, <strong>y.</strong> Ezek. 36:31; Isa. 30:22; Phil. 3:7-8, <strong>z.</strong> Joel 2:12-13; Ps. 51:1-4; Luke 15:7, 10; Acts 2:37</p></div>
 </details>
 
 
@@ -874,7 +874,7 @@ Answer: Although sanctification <span class="v-const">be</span><span class="v-mo
 <details class="scripture-proofs" id="wlc-q77-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>d.</strong> 2 Chron. 7:14; Ps. 119:57–64; Matt. 3:8; 2 Cor. 7:10; Luke 1:6, <strong>e.</strong> 1 Cor. 6:11; 1 Cor. 1:30, <strong>f.</strong> Rom. 4:6, 8, <strong>g.</strong> Ezek. 36:27; Heb. 9:13–14</p></div>
+<p><strong>d.</strong> 2 Chron. 7:14; Ps. 119:57-64; Matt. 3:8; 2 Cor. 7:10; Luke 1:6, <strong>e.</strong> 1 Cor. 6:11; 1 Cor. 1:30, <strong>f.</strong> Rom. 4:6, 8, <strong>g.</strong> Ezek. 36:27; Heb. 9:13-14</p></div>
 </details>
 
 
@@ -885,7 +885,7 @@ Answer: The imperfection of sanctification in believers <span class="v-const">ar
 <details class="scripture-proofs" id="wlc-q78-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>h.</strong> Rom. 3:24–25, <strong>i.</strong> Rom. 6:6, 14; Rom. 8:33–34, <strong>l.</strong> 1 John 2:12–14; Heb. 5:12–14, <strong>m.</strong> 1 John 1:8, 10, <strong>n.</strong> 2 Cor. 7:1; Phil. 3:12–14, <strong>o.</strong> Rom. 7:18, 23</p></div>
+<p><strong>h.</strong> Rom. 3:24-25, <strong>i.</strong> Rom. 6:6, 14; Rom. 8:33-34, <strong>l.</strong> 1 John 2:12-14; Heb. 5:12-14, <strong>m.</strong> 1 John 1:8, 10, <strong>n.</strong> 2 Cor. 7:1; Phil. 3:12-14, <strong>o.</strong> Rom. 7:18, 23</p></div>
 </details>
 
 
@@ -896,7 +896,7 @@ Answer: True believers, by reason of the unchangeable love of God,<sup class="pr
 <details class="scripture-proofs" id="wlc-q79-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>p.</strong> Heb. 12:1, <strong>q.</strong> Isa. 64:6; Gal. 5:16–18, <strong>r.</strong> Jer. 31:3, <strong>s.</strong> 2 Tim. 2:19; Heb. 13:20–21; 2 Sam. 23:5, <strong>t.</strong> 1 Cor. 1:8–9, <strong>u.</strong> Heb. 7:25; Luke 22:32</p></div>
+<p><strong>p.</strong> Heb. 12:1, <strong>q.</strong> Isa. 64:6; Gal. 5:16-18, <strong>r.</strong> Jer. 31:3, <strong>s.</strong> 2 Tim. 2:19; Heb. 13:20-21; 2 Sam. 23:5, <strong>t.</strong> 1 Cor. 1:8-9, <strong>u.</strong> Heb. 7:25; Luke 22:32</p></div>
 </details>
 
 
@@ -907,7 +907,7 @@ Answer: <span class="v-const">Such as</span><span class="v-modern">Those who</sp
 <details class="scripture-proofs" id="wlc-q80-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> 1 Cor. 2:12; 1 John 3:14, 18–19, 21, 24; 1 John 4:13, 16; Heb. 6:11–12, <strong>w.</strong> 1 John 3:9; 1 John 2:27, <strong>x.</strong> Jer. 32:40; John 10:28, <strong>y.</strong> 1 Pet. 1:5, <strong>z.</strong> 1 John 2:3; Heb. 10:19–23</p></div>
+<p><strong>a.</strong> 1 Cor. 2:12; 1 John 3:14, 18-19, 21, 24; 1 John 4:13, 16; Heb. 6:11-12, <strong>w.</strong> 1 John 3:9; 1 John 2:27, <strong>x.</strong> Jer. 32:40; John 10:28, <strong>y.</strong> 1 Pet. 1:5, <strong>z.</strong> 1 John 2:3; Heb. 10:19-23</p></div>
 </details>
 
 
@@ -918,7 +918,7 @@ Answer: Assurance of grace and salvation not being of the essence of faith,<sup 
 <details class="scripture-proofs" id="wlc-q81-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>b.</strong> Rom. 8:15–16, <strong>c.</strong> 1 John 5:13; Heb. 6:19–20; 2 Pet. 1:5–11, <strong>d.</strong> Eph. 1:13, <strong>e.</strong> Isa. 50:10; Ps. 88:1–3, 6–7, 9–10, 13–15, <strong>f.</strong> Ps. 77:1–12; Ps. 51:8, 12; Ps. 31:22</p></div>
+<p><strong>b.</strong> Rom. 8:15-16, <strong>c.</strong> 1 John 5:13; Heb. 6:19-20; 2 Pet. 1:5-11, <strong>d.</strong> Eph. 1:13, <strong>e.</strong> Isa. 50:10; Ps. 88:1-3, 6-7, 9-10, 13-15, <strong>f.</strong> Ps. 77:1-12; Ps. 51:8, 12; Ps. 31:22</p></div>
 </details>
 
 
@@ -941,7 +941,7 @@ Answer: The members of the invisible church have communicated to them in this li
 <details class="scripture-proofs" id="wlc-q83-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>g.</strong> 1 John 3:9; Ps. 73:15, 23; Isa. 54:7–10; 1 Pet. 4:12–14, <strong>h.</strong> 2 Cor. 3:18, <strong>i.</strong> Luke 23:43; 1 Thess. 4:17</p></div>
+<p><strong>g.</strong> 1 John 3:9; Ps. 73:15, 23; Isa. 54:7-10; 1 Pet. 4:12-14, <strong>h.</strong> 2 Cor. 3:18, <strong>i.</strong> Luke 23:43; 1 Thess. 4:17</p></div>
 </details>
 
 
@@ -964,7 +964,7 @@ Answer: The righteous shall be delivered from death itself at the last day, and 
 <details class="scripture-proofs" id="wlc-q85-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Eph. 2:5–6, <strong>m.</strong> Rom. 5:5; 2 Cor. 1:22, <strong>n.</strong> Rom. 5:1–2; Rom. 14:17; 2 Pet. 3:18, <strong>o.</strong> Gen. 4:13; Matt. 27:4; Heb. 10:27; Rom. 2:9; Mark 9:44, <strong>p.</strong> Rom. 6:23, <strong>q.</strong> Heb. 9:27, <strong>r.</strong> Rom. 5:12, <strong>s.</strong> 1 Cor. 15:26, 55–57</p></div>
+<p><strong>l.</strong> Eph. 2:5-6, <strong>m.</strong> Rom. 5:5; 2 Cor. 1:22, <strong>n.</strong> Rom. 5:1-2; Rom. 14:17; 2 Pet. 3:18, <strong>o.</strong> Gen. 4:13; Matt. 27:4; Heb. 10:27; Rom. 2:9; Mark 9:44, <strong>p.</strong> Rom. 6:23, <strong>q.</strong> Heb. 9:27, <strong>r.</strong> Rom. 5:12, <strong>s.</strong> 1 Cor. 15:26, 55-57</p></div>
 </details>
 
 
@@ -975,7 +975,7 @@ Answer: The communion in glory with Christ <span class="v-const">which</span><sp
 <details class="scripture-proofs" id="wlc-q86-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>t.</strong> Isa. 57:1–2; 2 Kings 22:20, <strong>u.</strong> Rev. 14:13; Eph. 5:27, <strong>w.</strong> Luke 23:43; Phil. 1:23, <strong>x.</strong> Heb. 12:23; Acts 7:55, 59, <strong>y.</strong> 2 Cor. 5:1, 6, 8; Phil. 1:23; Acts 3:21; Eph. 4:10; Luke 23:43</p></div>
+<p><strong>t.</strong> Isa. 57:1-2; 2 Kings 22:20, <strong>u.</strong> Rev. 14:13; Eph. 5:27, <strong>w.</strong> Luke 23:43; Phil. 1:23, <strong>x.</strong> Heb. 12:23; Acts 7:55, 59, <strong>y.</strong> 2 Cor. 5:1, 6, 8; Phil. 1:23; Acts 3:21; Eph. 4:10; Luke 23:43</p></div>
 </details>
 
 
@@ -986,7 +986,7 @@ Answer: We are to believe that at the last day there shall be a general resurrec
 <details class="scripture-proofs" id="wlc-q87-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Rom. 8:23; Ps. 16:9, <strong>b.</strong> 1 Thess. 4:14, 16, <strong>c.</strong> Isa. 57:2, <strong>d.</strong> Job 19:26–27, <strong>e.</strong> Luke 16:23–24; Acts 1:25, <strong>f.</strong> Dan. 12:2; Acts 24:15, <strong>z.</strong> 1 John 3:2; 1 Cor. 13:12</p></div>
+<p><strong>a.</strong> Rom. 8:23; Ps. 16:9, <strong>b.</strong> 1 Thess. 4:14, 16, <strong>c.</strong> Isa. 57:2, <strong>d.</strong> Job 19:26-27, <strong>e.</strong> Luke 16:23-24; Acts 1:25, <strong>f.</strong> Dan. 12:2; Acts 24:15, <strong>z.</strong> 1 John 3:2; 1 Cor. 13:12</p></div>
 </details>
 
 
@@ -997,7 +997,7 @@ Answer: Immediately after the resurrection shall follow the general and final ju
 <details class="scripture-proofs" id="wlc-q88-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>g.</strong> Job 19:26; 1 Cor. 15:51–53; 1 Thess. 4:15–17; John 5:28–29; Rom. 8:11, <strong>h.</strong> 1 Cor. 15:21–23, 42–44; Phil. 3:21, <strong>i.</strong> John 5:27–29; Matt. 25:33; 2 Pet. 2:4, 6–7, 14–15</p></div>
+<p><strong>g.</strong> Job 19:26; 1 Cor. 15:51-53; 1 Thess. 4:15-17; John 5:28-29; Rom. 8:11, <strong>h.</strong> 1 Cor. 15:21-23, 42-44; Phil. 3:21, <strong>i.</strong> John 5:27-29; Matt. 25:33; 2 Pet. 2:4, 6-7, 14-15</p></div>
 </details>
 
 
@@ -1008,7 +1008,7 @@ Answer: At the day of judgment, the wicked shall <span class="v-modern">then</sp
 <details class="scripture-proofs" id="wlc-q89-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Matt. 24:36, 42, 44; Mark 13:35–37, <strong>m.</strong> Matt. 25:33, <strong>n.</strong> Rom. 2:15–16, <strong>o.</strong> Matt. 25:41–43, <strong>p.</strong> Luke 16:26</p></div>
+<p><strong>l.</strong> Matt. 24:36, 42, 44; Mark 13:35-37, <strong>m.</strong> Matt. 25:33, <strong>n.</strong> Rom. 2:15-16, <strong>o.</strong> Matt. 25:41-43, <strong>p.</strong> Luke 16:26</p></div>
 </details>
 
 
@@ -1019,7 +1019,7 @@ Answer: At the day of judgment, the righteous, being caught up to Christ in the 
 <details class="scripture-proofs" id="wlc-q90-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>q.</strong> 1 Thess. 4:17; 1 Cor. 15:42–43, <strong>r.</strong> Matt. 25:33; Matt. 10:32, <strong>s.</strong> 1 Cor. 6:2–3, <strong>t.</strong> Matt. 25:34, 46, <strong>u.</strong> Eph. 5:27; Rev. 14:13, <strong>w.</strong> Ps. 16:11, <strong>x.</strong> Heb. 12:22–23, <strong>y.</strong> 1 John 3:2; Rom. 8:29</p></div>
+<p><strong>q.</strong> 1 Thess. 4:17; 1 Cor. 15:42-43, <strong>r.</strong> Matt. 25:33; Matt. 10:32, <strong>s.</strong> 1 Cor. 6:2-3, <strong>t.</strong> Matt. 25:34, 46, <strong>u.</strong> Eph. 5:27; Rev. 14:13, <strong>w.</strong> Ps. 16:11, <strong>x.</strong> Heb. 12:22-23, <strong>y.</strong> 1 John 3:2; Rom. 8:29</p></div>
 </details>
 
 
@@ -1044,7 +1044,7 @@ Answer: The rule of obedience revealed to Adam in the <span class="v-const">esta
 <details class="scripture-proofs" id="wlc-q92-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Gen. 1:26–27; Rom. 2:14–15, <strong>z.</strong> Deut. 29:29; Mic. 6:8; 1 John 5:2–3; Rom. 12:1–2; 1 Sam. 15:22</p></div>
+<p><strong>a.</strong> Gen. 1:26-27; Rom. 2:14-15, <strong>z.</strong> Deut. 29:29; Mic. 6:8; 1 John 5:2-3; Rom. 12:1-2; 1 Sam. 15:22</p></div>
 </details>
 
 
@@ -1067,7 +1067,7 @@ Answer: Although no man, since the fall, can attain to righteousness and life by
 <details class="scripture-proofs" id="wlc-q94-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>b.</strong> Deut. 5:1–3, 31, 33; Luke 10:26–27; 1 Thess. 5:23; Eph. 4:24, <strong>c.</strong> Luke 1:75; Acts 24:16; 1 Pet. 1:15–16, <strong>d.</strong> Rom. 10:5; Gal. 3:10, 12; Rom. 5:12, <strong>e.</strong> Rom. 8:3</p></div>
+<p><strong>b.</strong> Deut. 5:1-3, 31, 33; Luke 10:26-27; 1 Thess. 5:23; Eph. 4:24, <strong>c.</strong> Luke 1:75; Acts 24:16; 1 Pet. 1:15-16, <strong>d.</strong> Rom. 10:5; Gal. 3:10, 12; Rom. 5:12, <strong>e.</strong> Rom. 8:3</p></div>
 </details>
 
 
@@ -1078,7 +1078,7 @@ Answer: The moral law is of use to all men, to inform them of the holy nature an
 <details class="scripture-proofs" id="wlc-q95-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>f.</strong> 1 Tim. 1:8, <strong>g.</strong> Rom. 1:20; Lev. 11:44–45; Lev. 20:7–8; Rom. 7:12, <strong>h.</strong> Mic. 6:8; Rom. 1:32, <strong>i.</strong> Ps. 19:11–12; Rom. 3:20; Rom. 7:7; Rom. 3:9, 23, <strong>l.</strong> Gal. 3:21–22, 24</p></div>
+<p><strong>f.</strong> 1 Tim. 1:8, <strong>g.</strong> Rom. 1:20; Lev. 11:44-45; Lev. 20:7-8; Rom. 7:12, <strong>h.</strong> Mic. 6:8; Rom. 1:32, <strong>i.</strong> Ps. 19:11-12; Rom. 3:20; Rom. 7:7; Rom. 3:9, 23, <strong>l.</strong> Gal. 3:21-22, 24</p></div>
 </details>
 
 
@@ -1101,7 +1101,7 @@ Answer: Although <span class="v-const">they that</span><span class="v-modern">th
 <details class="scripture-proofs" id="wlc-q97-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>m.</strong> Rom. 10:4, <strong>n.</strong> Ps. 51:13; 1 Tim. 1:9–11, <strong>o.</strong> Gal. 3:24, <strong>p.</strong> Rom. 1:20; Rom. 2:15, <strong>q.</strong> Gal. 3:10, <strong>r.</strong> Rom. 6:14; Rom. 7:4, 6; Gal. 4:4–5; Col. 2:13–14, <strong>s.</strong> Rom. 3:20, <strong>t.</strong> Gal. 5:23; Rom. 8:1, <strong>u.</strong> Rom. 7:24–25; Gal. 3:13–14; Rom. 8:3–4; Acts 13:38–39, <strong>w.</strong> Luke 1:68–69, 74–75; Col. 1:12–14; Rom. 6:14, <strong>x.</strong> Deut. 30:19–20; Rom. 7:22; Rom. 12:2</p></div>
+<p><strong>m.</strong> Rom. 10:4, <strong>n.</strong> Ps. 51:13; 1 Tim. 1:9-11, <strong>o.</strong> Gal. 3:24, <strong>p.</strong> Rom. 1:20; Rom. 2:15, <strong>q.</strong> Gal. 3:10, <strong>r.</strong> Rom. 6:14; Rom. 7:4, 6; Gal. 4:4-5; Col. 2:13-14, <strong>s.</strong> Rom. 3:20, <strong>t.</strong> Gal. 5:23; Rom. 8:1, <strong>u.</strong> Rom. 7:24-25; Gal. 3:13-14; Rom. 8:3-4; Acts 13:38-39, <strong>w.</strong> Luke 1:68-69, 74-75; Col. 1:12-14; Rom. 6:14, <strong>x.</strong> Deut. 30:19-20; Rom. 7:22; Rom. 12:2</p></div>
 </details>
 
 
@@ -1112,7 +1112,7 @@ Answer: The moral law is <span class="v-const">summarily comprehended</span><spa
 <details class="scripture-proofs" id="wlc-q98-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>y.</strong> Deut. 4:13; Deut. 10:4; Rom. 13:8–10, <strong>z.</strong> Matt. 22:37–40; Matt. 19:17–19</p></div>
+<p><strong>y.</strong> Deut. 4:13; Deut. 10:4; Rom. 13:8-10, <strong>z.</strong> Matt. 22:37-40; Matt. 19:17-19</p></div>
 </details>
 
 
@@ -1131,7 +1131,7 @@ Answer: For the right understanding of the Ten Commandments, these rules are to 
 <details class="scripture-proofs" id="wlc-q99-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Ps. 19:7; Matt. 5:21–22, <strong>b.</strong> Rom. 7:14; Deut. 6:5; Matt. 22:37–39; Matt. 5:21–22, 27–28, 33–34, 37–39, 43–44, <strong>c.</strong> Col. 3:5; Amos 8:5; Prov. 1:19; 1 Tim. 6:10, <strong>d.</strong> Isa. 58:13; Deut. 6:13; Matt. 4:9–10; Matt. 15:4–6, <strong>e.</strong> Matt. 5:21–25; Eph. 4:28, <strong>f.</strong> Prov. 30:17, <strong>g.</strong> Jer. 18:7–8, <strong>h.</strong> Job 13:7–8; Rom. 3:8; Job 36:21; Heb. 11:25, <strong>i.</strong> Deut. 4:8–9; Luke 17:10; Matt. 12:7, <strong>l.</strong> Matt. 5:21–22, 27–28; Matt. 15:4–6; 1 Thess. 5:22; Gal. 5:26</p></div>
+<p><strong>a.</strong> Ps. 19:7; Matt. 5:21-22, <strong>b.</strong> Rom. 7:14; Deut. 6:5; Matt. 22:37-39; Matt. 5:21-22, 27-28, 33-34, 37-39, 43-44, <strong>c.</strong> Col. 3:5; Amos 8:5; Prov. 1:19; 1 Tim. 6:10, <strong>d.</strong> Isa. 58:13; Deut. 6:13; Matt. 4:9-10; Matt. 15:4-6, <strong>e.</strong> Matt. 5:21-25; Eph. 4:28, <strong>f.</strong> Prov. 30:17, <strong>g.</strong> Jer. 18:7-8, <strong>h.</strong> Job 13:7-8; Rom. 3:8; Job 36:21; Heb. 11:25, <strong>i.</strong> Deut. 4:8-9; Luke 17:10; Matt. 12:7, <strong>l.</strong> Matt. 5:21-22, 27-28; Matt. 15:4-6; 1 Thess. 5:22; Gal. 5:26</p></div>
 </details>
 
 
@@ -1146,7 +1146,7 @@ Answer: The preface to the Ten Commandments is contained in these words, I am th
 <details class="scripture-proofs" id="wlc-q101-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>m.</strong> Lev. 19:17; Gen. 18:19; Josh. 24:15; Deut. 6:6–7; Heb. 10:24–25, <strong>n.</strong> 2 Cor. 1:24, <strong>o.</strong> 1 Tim. 5:22; Eph. 5:11, <strong>p.</strong> Eph. 6:1–3</p></div>
+<p><strong>m.</strong> Lev. 19:17; Gen. 18:19; Josh. 24:15; Deut. 6:6-7; Heb. 10:24-25, <strong>n.</strong> 2 Cor. 1:24, <strong>o.</strong> 1 Tim. 5:22; Eph. 5:11, <strong>p.</strong> Eph. 6:1-3</p></div>
 </details>
 
 
@@ -1157,7 +1157,7 @@ Answer: The sum of the four commandments containing our duty to God, is, to love
 <details class="scripture-proofs" id="wlc-q102-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>q.</strong> Deut. 5:6, <strong>r.</strong> Isa. 44:6, <strong>u.</strong> Acts 17:24, 28, <strong>w.</strong> Gen. 17:7; Rom. 3:29, <strong>x.</strong> Luke 1:74–75; Gal. 5:1, <strong>y.</strong> 1 Pet. 1:15–19; Lev. 18:30; Lev. 19:37</p></div>
+<p><strong>q.</strong> Deut. 5:6, <strong>r.</strong> Isa. 44:6, <strong>u.</strong> Acts 17:24, 28, <strong>w.</strong> Gen. 17:7; Rom. 3:29, <strong>x.</strong> Luke 1:74-75; Gal. 5:1, <strong>y.</strong> 1 Pet. 1:15-19; Lev. 18:30; Lev. 19:37</p></div>
 </details>
 
 
@@ -1180,7 +1180,7 @@ Answer: The duties required in the first commandment <span class="v-const">are, 
 <details class="scripture-proofs" id="wlc-q104-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Deut. 5:7, <strong>b.</strong> 1 Chron. 28:9; Deut. 26:7; Isa. 43:10; Jer. 14:22, <strong>c.</strong> Ps. 95:6–7; Matt. 4:10; Ps. 29:2, <strong>d.</strong> Mal. 3:16, <strong>e.</strong> Ps. 63:6, <strong>g.</strong> Ps. 71:19, <strong>h.</strong> Mal. 1:6, <strong>i.</strong> Isa. 45:23; Josh. 24:15, 22, <strong>l.</strong> Deut. 6:5, <strong>m.</strong> Ps. 73:25, <strong>n.</strong> Isa. 8:13, <strong>p.</strong> Isa. 26:4, <strong>q.</strong> Ps. 130:7, <strong>r.</strong> Ps. 37:4, <strong>s.</strong> Ps. 32:11, <strong>t.</strong> Rom. 12:11; Num. 25:11, <strong>u.</strong> Phil. 4:6, <strong>w.</strong> Jer. 7:23, <strong>x.</strong> 1 John 3:22, <strong>y.</strong> Ps. 119:136; Jer. 31:18, <strong>z.</strong> Luke 10:27; Matt. 22:37–40</p></div>
+<p><strong>a.</strong> Deut. 5:7, <strong>b.</strong> 1 Chron. 28:9; Deut. 26:7; Isa. 43:10; Jer. 14:22, <strong>c.</strong> Ps. 95:6-7; Matt. 4:10; Ps. 29:2, <strong>d.</strong> Mal. 3:16, <strong>e.</strong> Ps. 63:6, <strong>g.</strong> Ps. 71:19, <strong>h.</strong> Mal. 1:6, <strong>i.</strong> Isa. 45:23; Josh. 24:15, 22, <strong>l.</strong> Deut. 6:5, <strong>m.</strong> Ps. 73:25, <strong>n.</strong> Isa. 8:13, <strong>p.</strong> Isa. 26:4, <strong>q.</strong> Ps. 130:7, <strong>r.</strong> Ps. 37:4, <strong>s.</strong> Ps. 32:11, <strong>t.</strong> Rom. 12:11; Num. 25:11, <strong>u.</strong> Phil. 4:6, <strong>w.</strong> Jer. 7:23, <strong>x.</strong> 1 John 3:22, <strong>y.</strong> Ps. 119:136; Jer. 31:18, <strong>z.</strong> Luke 10:27; Matt. 22:37-40</p></div>
 </details>
 
 
@@ -1191,7 +1191,7 @@ Answer: <span class="v-const">The</span> sins forbidden in the first <span class
 <details class="scripture-proofs" id="wlc-q105-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Ps. 14:1; Eph. 2:12, <strong>b.</strong> Jer. 2:27–28; 1 Thess. 1:9, <strong>c.</strong> Ps. 81:10–11; Rom. 1:21, <strong>d.</strong> Isa. 43:22–24, <strong>e.</strong> Jer. 4:22; Hos. 4:1, 6, <strong>f.</strong> Jer. 2:32, <strong>g.</strong> Acts 17:23, 29, <strong>h.</strong> Isa. 40:18, <strong>i.</strong> Ps. 50:21; Deut. 29:29, <strong>l.</strong> Heb. 12:16, <strong>m.</strong> Rom. 1:30, <strong>n.</strong> 2 Tim. 3:2, <strong>o.</strong> Phil. 2:21, <strong>p.</strong> 1 John 2:15–16; Col. 3:2, 5; 1 Sam. 2:29, <strong>q.</strong> 1 John 4:1, <strong>r.</strong> Heb. 3:12, <strong>s.</strong> Gal. 5:20, <strong>t.</strong> Acts 26:9, <strong>u.</strong> Ps. 78:22, <strong>w.</strong> Gen. 4:13, <strong>x.</strong> Jer. 5:3, <strong>y.</strong> Isa. 42:25, <strong>z.</strong> Rom. 2:5; Jer. 13:15; Ps. 19:13; Zeph. 1:12; Matt. 4:7; Rom. 3:8; Jer. 17:5; 2 Tim. 3:4; Gal. 4:17; Rom. 10:2; John 16:2; Luke 9:54–55; Rev. 3:16; Rev. 3:1; Ezek. 14:5; Isa. 1:4–5; Hos. 4:12</p></div>
+<p><strong>a.</strong> Ps. 14:1; Eph. 2:12, <strong>b.</strong> Jer. 2:27-28; 1 Thess. 1:9, <strong>c.</strong> Ps. 81:10-11; Rom. 1:21, <strong>d.</strong> Isa. 43:22-24, <strong>e.</strong> Jer. 4:22; Hos. 4:1, 6, <strong>f.</strong> Jer. 2:32, <strong>g.</strong> Acts 17:23, 29, <strong>h.</strong> Isa. 40:18, <strong>i.</strong> Ps. 50:21; Deut. 29:29, <strong>l.</strong> Heb. 12:16, <strong>m.</strong> Rom. 1:30, <strong>n.</strong> 2 Tim. 3:2, <strong>o.</strong> Phil. 2:21, <strong>p.</strong> 1 John 2:15-16; Col. 3:2, 5; 1 Sam. 2:29, <strong>q.</strong> 1 John 4:1, <strong>r.</strong> Heb. 3:12, <strong>s.</strong> Gal. 5:20, <strong>t.</strong> Acts 26:9, <strong>u.</strong> Ps. 78:22, <strong>w.</strong> Gen. 4:13, <strong>x.</strong> Jer. 5:3, <strong>y.</strong> Isa. 42:25, <strong>z.</strong> Rom. 2:5; Jer. 13:15; Ps. 19:13; Zeph. 1:12; Matt. 4:7; Rom. 3:8; Jer. 17:5; 2 Tim. 3:4; Gal. 4:17; Rom. 10:2; John 16:2; Luke 9:54-55; Rev. 3:16; Rev. 3:1; Ezek. 14:5; Isa. 1:4-5; Hos. 4:12</p></div>
 </details>
 
 
@@ -1214,7 +1214,7 @@ Answer: The second commandment is, <span class="v-const">Thou shalt</span><span 
 <details class="scripture-proofs" id="wlc-q107-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Deut. 5:8–10, <strong>y.</strong> Ps. 44:20–21; Deut. 30:17–18; Ezek. 8:5–6, 12, <strong>z.</strong> 1 Chron. 28:9</p></div>
+<p><strong>a.</strong> Deut. 5:8-10, <strong>y.</strong> Ps. 44:20-21; Deut. 30:17-18; Ezek. 8:5-6, 12, <strong>z.</strong> 1 Chron. 28:9</p></div>
 </details>
 
 
@@ -1225,7 +1225,7 @@ Answer: The duties required in the second commandment <span class="v-const">are,
 <details class="scripture-proofs" id="wlc-q108-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>b.</strong> Deut. 12:32; Deut. 32:46–47; Matt. 28:20; 1 Tim. 6:13–14; Acts 2:42, <strong>c.</strong> Phil. 4:6; Eph. 5:20, <strong>d.</strong> Deut. 17:18–19; Acts 15:21; 2 Tim. 4:2; Acts 10:33, <strong>e.</strong> Matt. 28:19; 1 Cor. 11:23–30, <strong>f.</strong> Matt. 18:15–17; Matt. 16:19</p></div>
+<p><strong>b.</strong> Deut. 12:32; Deut. 32:46-47; Matt. 28:20; 1 Tim. 6:13-14; Acts 2:42, <strong>c.</strong> Phil. 4:6; Eph. 5:20, <strong>d.</strong> Deut. 17:18-19; Acts 15:21; 2 Tim. 4:2; Acts 10:33, <strong>e.</strong> Matt. 28:19; 1 Cor. 11:23-30, <strong>f.</strong> Matt. 18:15-17; Matt. 16:19</p></div>
 </details>
 
 
@@ -1236,7 +1236,7 @@ Answer: <span class="v-const"><span class="v-const">The</span></span> sins forbi
 <details class="scripture-proofs" id="wlc-q109-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Deut. 4:2, <strong>b.</strong> Ps. 106:39, <strong>c.</strong> Matt. 15:9, <strong>d.</strong> 1 Pet. 1:18, <strong>e.</strong> Jer. 44:17, <strong>f.</strong> Isa. 65:3–5; Gal. 1:13–14, <strong>g.</strong> 1 Sam. 13:11–12; 1 Sam. 15:21, <strong>h.</strong> Acts 8:18–19, <strong>i.</strong> Rom. 2:22; Mal. 3:8, <strong>l.</strong> Matt. 22:5; Mal. 1:7, 13, <strong>m.</strong> Matt. 23:13; Acts 13:44–45, <strong>n.</strong> Num. 15:39, <strong>o.</strong> Deut. 13:6–8, <strong>p.</strong> Hos. 5:11; Mic. 6:16, <strong>q.</strong> 1 Kings 11:33; 1 Kings 12:33, <strong>r.</strong> Deut. 12:30–32; Lev. 10:1–2; Jer. 19:5, <strong>s.</strong> Deut. 4:15–16; Acts 17:29; Rom. 1:21–23, 25, <strong>t.</strong> Gal. 4:8; Dan. 3:18, <strong>x.</strong> 1 Kings 18:26, 28; Isa. 65:11, <strong>y.</strong> Acts 17:22; Col. 2:21–23, <strong>z.</strong> Mal. 1:7–8, 14</p></div>
+<p><strong>a.</strong> Deut. 4:2, <strong>b.</strong> Ps. 106:39, <strong>c.</strong> Matt. 15:9, <strong>d.</strong> 1 Pet. 1:18, <strong>e.</strong> Jer. 44:17, <strong>f.</strong> Isa. 65:3-5; Gal. 1:13-14, <strong>g.</strong> 1 Sam. 13:11-12; 1 Sam. 15:21, <strong>h.</strong> Acts 8:18-19, <strong>i.</strong> Rom. 2:22; Mal. 3:8, <strong>l.</strong> Matt. 22:5; Mal. 1:7, 13, <strong>m.</strong> Matt. 23:13; Acts 13:44-45, <strong>n.</strong> Num. 15:39, <strong>o.</strong> Deut. 13:6-8, <strong>p.</strong> Hos. 5:11; Mic. 6:16, <strong>q.</strong> 1 Kings 11:33; 1 Kings 12:33, <strong>r.</strong> Deut. 12:30-32; Lev. 10:1-2; Jer. 19:5, <strong>s.</strong> Deut. 4:15-16; Acts 17:29; Rom. 1:21-23, 25, <strong>t.</strong> Gal. 4:8; Dan. 3:18, <strong>x.</strong> 1 Kings 18:26, 28; Isa. 65:11, <strong>y.</strong> Acts 17:22; Col. 2:21-23, <strong>z.</strong> Mal. 1:7-8, 14</p></div>
 </details>
 
 
@@ -1247,7 +1247,7 @@ Answer: The reasons annexed to the second commandment, <span class="v-const">the
 <details class="scripture-proofs" id="wlc-q110-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>p.</strong> Ps. 45:11; Rev. 15:3–4; Ps. 95:2–3, 6–7; Isa. 54:5, <strong>r.</strong> 1 Cor. 10:20–22; Ezek. 16:26–27; Jer. 7:18–20; Deut. 32:16–20, <strong>s.</strong> Hos. 2:2–4</p></div>
+<p><strong>p.</strong> Ps. 45:11; Rev. 15:3-4; Ps. 95:2-3, 6-7; Isa. 54:5, <strong>r.</strong> 1 Cor. 10:20-22; Ezek. 16:26-27; Jer. 7:18-20; Deut. 32:16-20, <strong>s.</strong> Hos. 2:2-4</p></div>
 </details>
 
 
@@ -1270,7 +1270,7 @@ Answer: The third commandment requires, that the name of God, his titles, attrib
 <details class="scripture-proofs" id="wlc-q112-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> 1 Tim. 2:8, <strong>b.</strong> Jer. 4:2, <strong>t.</strong> Deut. 5:29, <strong>u.</strong> Deut. 5:11, <strong>w.</strong> Matt. 6:9; Deut. 28:58; Ps. 68:4; Ps. 29:2; 1 Chron. 29:10–13; Rev. 15:3–4, <strong>x.</strong> Luke 1:6; Mal. 1:11, 14, <strong>y.</strong> Ps. 138:2, <strong>z.</strong> 1 Cor. 11:24–25, 28–29</p></div>
+<p><strong>a.</strong> 1 Tim. 2:8, <strong>b.</strong> Jer. 4:2, <strong>t.</strong> Deut. 5:29, <strong>u.</strong> Deut. 5:11, <strong>w.</strong> Matt. 6:9; Deut. 28:58; Ps. 68:4; Ps. 29:2; 1 Chron. 29:10-13; Rev. 15:3-4, <strong>x.</strong> Luke 1:6; Mal. 1:11, 14, <strong>y.</strong> Ps. 138:2, <strong>z.</strong> 1 Cor. 11:24-25, 28-29</p></div>
 </details>
 
 
@@ -1281,7 +1281,7 @@ Answer: The sins forbidden in the third commandment are, <span class="v-const">t
 <details class="scripture-proofs" id="wlc-q113-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> 1 Sam. 17:43; 2 Sam. 16:5, <strong>b.</strong> Jer. 5:7; Jer. 23:10, <strong>c.</strong> Deut. 23:18; Acts 23:12, 14, <strong>d.</strong> Est. 3:7; Est. 9:24; Ps. 22:18, <strong>e.</strong> Ps. 24:4; Ezek. 17:16, 18–19, <strong>f.</strong> Mark 6:26; 1 Sam. 25:22, 32–34, <strong>g.</strong> Rom. 9:14, 19–20, <strong>h.</strong> Deut. 29:29, <strong>i.</strong> Rom. 3:5, 7; Rom. 6:1–2, <strong>l.</strong> Matt. 5:21–22, 27–28, 31–35, 38–39, 43–44, <strong>m.</strong> Ezek. 13:22, <strong>n.</strong> 2 Pet. 3:16; Matt. 22:24–31, <strong>o.</strong> Isa. 22:13; Jer. 23:34, 36, 38; 1 Tim. 1:4, 6–7; 1 Tim. 6:4–5, 20; 2 Tim. 2:14; Deut. 18:10–14; Acts 19:13, <strong>p.</strong> Mal. 2:2, <strong>q.</strong> Acts 17:23, <strong>r.</strong> Prov. 30:9, <strong>s.</strong> Mal. 1:6–7, 12; Mal. 3:14, <strong>t.</strong> 1 Sam. 4:3–5; Jer. 7:4, 9–10, 14, 31; Col. 2:20–22, <strong>u.</strong> 2 Kings 18:30, 35; Ps. 139:20, <strong>w.</strong> Ps. 50:16–17, <strong>x.</strong> Isa. 5:12, <strong>y.</strong> 2 Kings 19:22; Lev. 24:11, <strong>z.</strong> Zech. 5:4; Zech. 8:17</p></div>
+<p><strong>a.</strong> 1 Sam. 17:43; 2 Sam. 16:5, <strong>b.</strong> Jer. 5:7; Jer. 23:10, <strong>c.</strong> Deut. 23:18; Acts 23:12, 14, <strong>d.</strong> Est. 3:7; Est. 9:24; Ps. 22:18, <strong>e.</strong> Ps. 24:4; Ezek. 17:16, 18-19, <strong>f.</strong> Mark 6:26; 1 Sam. 25:22, 32-34, <strong>g.</strong> Rom. 9:14, 19-20, <strong>h.</strong> Deut. 29:29, <strong>i.</strong> Rom. 3:5, 7; Rom. 6:1-2, <strong>l.</strong> Matt. 5:21-22, 27-28, 31-35, 38-39, 43-44, <strong>m.</strong> Ezek. 13:22, <strong>n.</strong> 2 Pet. 3:16; Matt. 22:24-31, <strong>o.</strong> Isa. 22:13; Jer. 23:34, 36, 38; 1 Tim. 1:4, 6-7; 1 Tim. 6:4-5, 20; 2 Tim. 2:14; Deut. 18:10-14; Acts 19:13, <strong>p.</strong> Mal. 2:2, <strong>q.</strong> Acts 17:23, <strong>r.</strong> Prov. 30:9, <strong>s.</strong> Mal. 1:6-7, 12; Mal. 3:14, <strong>t.</strong> 1 Sam. 4:3-5; Jer. 7:4, 9-10, 14, 31; Col. 2:20-22, <strong>u.</strong> 2 Kings 18:30, 35; Ps. 139:20, <strong>w.</strong> Ps. 50:16-17, <strong>x.</strong> Isa. 5:12, <strong>y.</strong> 2 Kings 19:22; Lev. 24:11, <strong>z.</strong> Zech. 5:4; Zech. 8:17</p></div>
 </details>
 
 
@@ -1304,7 +1304,7 @@ Answer: The fourth commandment is, Remember the <span class="v-const">sabbath</s
 <details class="scripture-proofs" id="wlc-q115-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>f.</strong> Lev. 19:12, <strong>g.</strong> Deut. 28:58–59; Ezek. 36:21–23, <strong>h.</strong> 1 Sam. 2:29; 1 Sam. 3:13</p></div>
+<p><strong>f.</strong> Lev. 19:12, <strong>g.</strong> Deut. 28:58-59; Ezek. 36:21-23, <strong>h.</strong> 1 Sam. 2:29; 1 Sam. 3:13</p></div>
 </details>
 
 
@@ -1315,7 +1315,7 @@ Answer: The fourth commandment <span class="v-const">requireth</span><span class
 <details class="scripture-proofs" id="wlc-q116-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>i.</strong> Deut. 5:12–15; Deut. 5:12–14; Gen. 2:2–3; 1 Cor. 16:1–2; Acts 20:7; John 20:19, 26; Matt. 5:17–18; Isa. 56:2, 4, 6–7</p>
+<p><strong>i.</strong> Deut. 5:12-15; Deut. 5:12-14; Gen. 2:2-3; 1 Cor. 16:1-2; Acts 20:7; John 20:19, 26; Matt. 5:17-18; Isa. 56:2, 4, 6-7</p>
 </div>
 </details>
 
@@ -1327,7 +1327,7 @@ Answer: The <span class="v-const">sabbath</span><span class="v-modern">Sabbath</
 <details class="scripture-proofs" id="wlc-q117-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Rev. 1:10, <strong>n.</strong> Jer. 17:21–22; Neh. 13:15–22, <strong>o.</strong> Matt. 12:1–5, <strong>p.</strong> Isa. 58:13–14; Luke 4:16; Acts 20:7; 1 Cor. 16:1–2</p></div>
+<p><strong>l.</strong> Rev. 1:10, <strong>n.</strong> Jer. 17:21-22; Neh. 13:15-22, <strong>o.</strong> Matt. 12:1-5, <strong>p.</strong> Isa. 58:13-14; Luke 4:16; Acts 20:7; 1 Cor. 16:1-2</p></div>
 </details>
 
 
@@ -1350,7 +1350,7 @@ Answer: The sins forbidden in the fourth commandment are, all omissions of the d
 <details class="scripture-proofs" id="wlc-q119-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>q.</strong> Luke 23:54, 56; Neh. 13:19, <strong>r.</strong> Josh. 24:15; Neh. 13:15–17; Jer. 17:20–22, <strong>s.</strong> Ezek. 22:26</p></div>
+<p><strong>q.</strong> Luke 23:54, 56; Neh. 13:19, <strong>r.</strong> Josh. 24:15; Neh. 13:15-17; Jer. 17:20-22, <strong>s.</strong> Ezek. 22:26</p></div>
 </details>
 
 
@@ -1373,7 +1373,7 @@ Answer: The word Remember is set in the beginning of the fourth commandment,<sup
 <details class="scripture-proofs" id="wlc-q121-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>c.</strong> Ezek. 20:12, 19–20; Ps. 92:13–14, <strong>d.</strong> Gen. 2:2–3; Ps. 118:22, 24; Rev. 1:10, <strong>e.</strong> Ezek. 22:26, <strong>f.</strong> Neh. 9:14, <strong>h.</strong> Deut. 5:14–15; Amos 8:5, <strong>t.</strong> Amos 8:5; Acts 20:7, 9; Ezek. 33:30–32; Mal. 1:13, <strong>u.</strong> Ezek. 23:38, <strong>w.</strong> Jer. 17:24, 27; Isa. 58:13–14</p></div>
+<p><strong>c.</strong> Ezek. 20:12, 19-20; Ps. 92:13-14, <strong>d.</strong> Gen. 2:2-3; Ps. 118:22, 24; Rev. 1:10, <strong>e.</strong> Ezek. 22:26, <strong>f.</strong> Neh. 9:14, <strong>h.</strong> Deut. 5:14-15; Amos 8:5, <strong>t.</strong> Amos 8:5; Acts 20:7, 9; Ezek. 33:30-32; Mal. 1:13, <strong>u.</strong> Ezek. 23:38, <strong>w.</strong> Jer. 17:24, 27; Isa. 58:13-14</p></div>
 </details>
 
 
@@ -1408,7 +1408,7 @@ Answer: By father and mother, in the fifth commandment, are meant, not only natu
 <details class="scripture-proofs" id="wlc-q124-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>i.</strong> Lam. 1:7; Jer. 17:21–23; Neh. 13:15–22; Matt. 22:39, <strong>l.</strong> Matt. 7:12, <strong>m.</strong> Deut. 5:16, <strong>n.</strong> Prov. 23:22, 25; Eph. 6:1–2, <strong>o.</strong> 1 Tim. 5:1–2, <strong>p.</strong> Gen. 4:20–21; Gen. 45:8</p></div>
+<p><strong>i.</strong> Lam. 1:7; Jer. 17:21-23; Neh. 13:15-22; Matt. 22:39, <strong>l.</strong> Matt. 7:12, <strong>m.</strong> Deut. 5:16, <strong>n.</strong> Prov. 23:22, 25; Eph. 6:1-2, <strong>o.</strong> 1 Tim. 5:1-2, <strong>p.</strong> Gen. 4:20-21; Gen. 45:8</p></div>
 </details>
 
 
@@ -1443,7 +1443,7 @@ Answer: The honor <span class="v-const">which</span><span class="v-modern">that<
 <details class="scripture-proofs" id="wlc-q127-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> 1 Tim. 2:1–2, <strong>b.</strong> Heb. 13:7; Phil. 3:17, <strong>c.</strong> Eph. 6:1–2, 5–7; 1 Pet. 2:13–14; Heb. 13:17; Rom. 13:1–5; Prov. 4:3–4, <strong>d.</strong> Heb. 12:9; 1 Pet. 2:18–20, <strong>q.</strong> 2 Kings 5:13, <strong>r.</strong> 2 Kings 2:12; Gal. 4:19; 2 Kings 13:14, <strong>s.</strong> Isa. 49:23, <strong>t.</strong> Eph. 6:4; 2 Cor. 12:14; 1 Thess. 2:7–8, 11; Num. 11:11–12, <strong>u.</strong> 1 Cor. 4:14–16; 2 Kings 5:13, <strong>w.</strong> Eph. 5:21; 1 Pet. 2:17; Rom. 12:10; Rom. 13:1, 7; Eph. 5:22, 24, <strong>x.</strong> Mal. 1:6; Lev. 19:3, <strong>y.</strong> Prov. 31:28; 1 Pet. 3:6, <strong>z.</strong> Lev. 19:32; 1 Kings 2:19</p></div>
+<p><strong>a.</strong> 1 Tim. 2:1-2, <strong>b.</strong> Heb. 13:7; Phil. 3:17, <strong>c.</strong> Eph. 6:1-2, 5-7; 1 Pet. 2:13-14; Heb. 13:17; Rom. 13:1-5; Prov. 4:3-4, <strong>d.</strong> Heb. 12:9; 1 Pet. 2:18-20, <strong>q.</strong> 2 Kings 5:13, <strong>r.</strong> 2 Kings 2:12; Gal. 4:19; 2 Kings 13:14, <strong>s.</strong> Isa. 49:23, <strong>t.</strong> Eph. 6:4; 2 Cor. 12:14; 1 Thess. 2:7-8, 11; Num. 11:11-12, <strong>u.</strong> 1 Cor. 4:14-16; 2 Kings 5:13, <strong>w.</strong> Eph. 5:21; 1 Pet. 2:17; Rom. 12:10; Rom. 13:1, 7; Eph. 5:22, 24, <strong>x.</strong> Mal. 1:6; Lev. 19:3, <strong>y.</strong> Prov. 31:28; 1 Pet. 3:6, <strong>z.</strong> Lev. 19:32; 1 Kings 2:19</p></div>
 </details>
 
 
@@ -1454,7 +1454,7 @@ Answer: The sins of inferiors against their superiors are, all neglect of the du
 <details class="scripture-proofs" id="wlc-q128-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>f.</strong> 1 Sam. 26:15–16; 2 Sam. 18:3; Est. 6:2, <strong>g.</strong> Matt. 22:21; Rom. 13:6–7; 1 Tim. 5:17–18; Gal. 6:6; Gen. 45:11, <strong>h.</strong> Gen. 9:23; 1 Pet. 2:18; Prov. 23:22, <strong>i.</strong> Ps. 127:3–5; Prov. 31:23; Matt. 15:4–6; Rom. 13:8, <strong>l.</strong> Num. 11:28–29, <strong>m.</strong> 1 Sam. 8:7; Isa. 3:5</p></div>
+<p><strong>f.</strong> 1 Sam. 26:15-16; 2 Sam. 18:3; Est. 6:2, <strong>g.</strong> Matt. 22:21; Rom. 13:6-7; 1 Tim. 5:17-18; Gal. 6:6; Gen. 45:11, <strong>h.</strong> Gen. 9:23; 1 Pet. 2:18; Prov. 23:22, <strong>i.</strong> Ps. 127:3-5; Prov. 31:23; Matt. 15:4-6; Rom. 13:8, <strong>l.</strong> Num. 11:28-29, <strong>m.</strong> 1 Sam. 8:7; Isa. 3:5</p></div>
 </details>
 
 
@@ -1465,7 +1465,7 @@ Answer: It is required of superiors, according to that power they receive from G
 <details class="scripture-proofs" id="wlc-q129-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> 1 Pet. 3:7, <strong>b.</strong> 1 Pet. 2:14; Rom. 13:3, <strong>c.</strong> Est. 6:3, <strong>d.</strong> Rom. 13:3–4, <strong>e.</strong> Prov. 29:15; 1 Pet. 2:14, <strong>f.</strong> Isa. 1:10, 17; Job 29:12–17, <strong>g.</strong> Eph. 6:4, <strong>h.</strong> 1 Tim. 5:8; 1 Tim. 4:12; 1 Kings 3:28, <strong>n.</strong> 2 Sam. 15:10, <strong>p.</strong> 1 Sam. 10:27, <strong>q.</strong> 1 Sam. 2:25, <strong>r.</strong> Deut. 21:18–21, <strong>s.</strong> Prov. 30:11, 17, <strong>t.</strong> Prov. 19:26, <strong>u.</strong> Col. 3:19, <strong>w.</strong> 1 Sam. 12:23; Job 1:5, <strong>x.</strong> 1 Kings 8:55–56; Heb. 7:7, <strong>y.</strong> Deut. 6:6–7, <strong>z.</strong> Eph. 6:4</p></div>
+<p><strong>a.</strong> 1 Pet. 3:7, <strong>b.</strong> 1 Pet. 2:14; Rom. 13:3, <strong>c.</strong> Est. 6:3, <strong>d.</strong> Rom. 13:3-4, <strong>e.</strong> Prov. 29:15; 1 Pet. 2:14, <strong>f.</strong> Isa. 1:10, 17; Job 29:12-17, <strong>g.</strong> Eph. 6:4, <strong>h.</strong> 1 Tim. 5:8; 1 Tim. 4:12; 1 Kings 3:28, <strong>n.</strong> 2 Sam. 15:10, <strong>p.</strong> 1 Sam. 10:27, <strong>q.</strong> 1 Sam. 2:25, <strong>r.</strong> Deut. 21:18-21, <strong>s.</strong> Prov. 30:11, 17, <strong>t.</strong> Prov. 19:26, <strong>u.</strong> Col. 3:19, <strong>w.</strong> 1 Sam. 12:23; Job 1:5, <strong>x.</strong> 1 Kings 8:55-56; Heb. 7:7, <strong>y.</strong> Deut. 6:6-7, <strong>z.</strong> Eph. 6:4</p></div>
 </details>
 
 
@@ -1476,7 +1476,7 @@ Answer: The sins of superiors are, besides the neglect of the duties required of
 <details class="scripture-proofs" id="wlc-q130-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>m.</strong> Ezek. 34:2–4, <strong>n.</strong> Phil. 2:21, <strong>o.</strong> John 5:44; John 7:18, <strong>p.</strong> Isa. 56:10–11; Deut. 17:17, <strong>q.</strong> Acts 4:17–18; Dan. 3:4–6, <strong>r.</strong> Matt. 23:2, 4, <strong>s.</strong> Matt. 14:8; Mark 6:24, <strong>t.</strong> 2 Sam. 13:28, <strong>u.</strong> Jer. 6:13–14; Judg. 20:13–14</p></div>
+<p><strong>m.</strong> Ezek. 34:2-4, <strong>n.</strong> Phil. 2:21, <strong>o.</strong> John 5:44; John 7:18, <strong>p.</strong> Isa. 56:10-11; Deut. 17:17, <strong>q.</strong> Acts 4:17-18; Dan. 3:4-6, <strong>r.</strong> Matt. 23:2, 4, <strong>s.</strong> Matt. 14:8; Mark 6:24, <strong>t.</strong> 2 Sam. 13:28, <strong>u.</strong> Jer. 6:13-14; Judg. 20:13-14</p></div>
 </details>
 
 
@@ -1487,7 +1487,7 @@ Answer: The duties of equals are, to regard the dignity and worth of each other,
 <details class="scripture-proofs" id="wlc-q131-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Gen. 9:21; 1 Kings 12:13–16; 1 Kings 1:6; 1 Sam. 2:29–31, <strong>b.</strong> 1 Pet. 2:17, <strong>w.</strong> John 7:46–49; Col. 3:21; John 9:28, <strong>x.</strong> 1 Pet. 2:18–20; Deut. 25:3, <strong>y.</strong> Gen. 38:11, 26; Acts 18:17; 1 Sam. 23:15–17; Lev. 19:29; Isa. 58:7, <strong>z.</strong> Eph. 6:4</p></div>
+<p><strong>a.</strong> Gen. 9:21; 1 Kings 12:13-16; 1 Kings 1:6; 1 Sam. 2:29-31, <strong>b.</strong> 1 Pet. 2:17, <strong>w.</strong> John 7:46-49; Col. 3:21; John 9:28, <strong>x.</strong> 1 Pet. 2:18-20; Deut. 25:3, <strong>y.</strong> Gen. 38:11, 26; Acts 18:17; 1 Sam. 23:15-17; Lev. 19:29; Isa. 58:7, <strong>z.</strong> Eph. 6:4</p></div>
 </details>
 
 
@@ -1522,7 +1522,7 @@ Answer: The sixth commandment is, <span class="v-const">Thou shalt</span><span c
 <details class="scripture-proofs" id="wlc-q134-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>c.</strong> Rom. 12:10; Phil. 2:3, <strong>d.</strong> Rom. 12:15–16; Phil. 2:3, <strong>e.</strong> Rom. 13:8, <strong>f.</strong> 2 Tim. 3:3; Prov. 14:21; Isa. 65:5, <strong>g.</strong> Acts 7:9; Gal. 5:26, <strong>h.</strong> Num. 12:2, <strong>i.</strong> Luke 22:24, <strong>l.</strong> Eph. 6:2–3; Deut. 5:16; 1 Kings 8:25, <strong>m.</strong> Deut. 5:17</p></div>
+<p><strong>c.</strong> Rom. 12:10; Phil. 2:3, <strong>d.</strong> Rom. 12:15-16; Phil. 2:3, <strong>e.</strong> Rom. 13:8, <strong>f.</strong> 2 Tim. 3:3; Prov. 14:21; Isa. 65:5, <strong>g.</strong> Acts 7:9; Gal. 5:26, <strong>h.</strong> Num. 12:2, <strong>i.</strong> Luke 22:24, <strong>l.</strong> Eph. 6:2-3; Deut. 5:16; 1 Kings 8:25, <strong>m.</strong> Deut. 5:17</p></div>
 </details>
 
 
@@ -1533,7 +1533,7 @@ Answer: The duties required in the sixth commandment are, all careful studies, a
 <details class="scripture-proofs" id="wlc-q135-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> 1 Tim. 5:23, <strong>b.</strong> Isa. 38:21, <strong>c.</strong> Ps. 127:2, <strong>d.</strong> 2 Thess. 3:12, <strong>e.</strong> Mark 6:31, <strong>f.</strong> 1 Sam. 19:4–5; 1 Sam. 22:13–14, <strong>n.</strong> Eph. 5:28–29, <strong>o.</strong> 1 Kings 18:4, <strong>p.</strong> Jer. 26:15–16; Acts 23:12, 16–17, 21, 27, <strong>q.</strong> Eph. 4:26–27, <strong>r.</strong> 2 Sam. 2:22–23; Deut. 22:8, <strong>s.</strong> Matt. 4:6–7; Prov. 1:10–11, 15–16, <strong>t.</strong> Gen. 37:21–22; 1 Sam. 24:12, <strong>u.</strong> Ps. 82:4; Prov. 24:11–12, <strong>w.</strong> Heb. 12:9; 2 Sam. 16:10–12, <strong>x.</strong> 1 Thess. 4:11; 1 Pet. 3:3–4; Ps. 37:8, 11, <strong>y.</strong> Prov. 17:22, <strong>z.</strong> Prov. 23:20; Prov. 25:16, 27</p></div>
+<p><strong>a.</strong> 1 Tim. 5:23, <strong>b.</strong> Isa. 38:21, <strong>c.</strong> Ps. 127:2, <strong>d.</strong> 2 Thess. 3:12, <strong>e.</strong> Mark 6:31, <strong>f.</strong> 1 Sam. 19:4-5; 1 Sam. 22:13-14, <strong>n.</strong> Eph. 5:28-29, <strong>o.</strong> 1 Kings 18:4, <strong>p.</strong> Jer. 26:15-16; Acts 23:12, 16-17, 21, 27, <strong>q.</strong> Eph. 4:26-27, <strong>r.</strong> 2 Sam. 2:22-23; Deut. 22:8, <strong>s.</strong> Matt. 4:6-7; Prov. 1:10-11, 15-16, <strong>t.</strong> Gen. 37:21-22; 1 Sam. 24:12, <strong>u.</strong> Ps. 82:4; Prov. 24:11-12, <strong>w.</strong> Heb. 12:9; 2 Sam. 16:10-12, <strong>x.</strong> 1 Thess. 4:11; 1 Pet. 3:3-4; Ps. 37:8, 11, <strong>y.</strong> Prov. 17:22, <strong>z.</strong> Prov. 23:20; Prov. 25:16, 27</p></div>
 </details>
 
 
@@ -1544,7 +1544,7 @@ Answer: <span class="v-const">The</span> sins forbidden in the sixth commandment
 <details class="scripture-proofs" id="wlc-q136-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Matt. 6:31, 34, <strong>g.</strong> Rom. 13:10, <strong>h.</strong> Luke 10:33–34, <strong>i.</strong> Col. 3:12–13, <strong>l.</strong> 1 Pet. 3:8–11; 1 Cor. 4:12–13; Prov. 15:1; Judg. 8:1–3, <strong>m.</strong> Matt. 5:24; Eph. 4:2, 32; Rom. 12:17, 20–21; 1 Thess. 5:14; Matt. 25:35–36; Prov. 31:8–9; Job 31:19–20; Isa. 58:7, <strong>o.</strong> Acts 16:28, <strong>p.</strong> Gen. 9:6, <strong>q.</strong> Num. 35:31, 33; Rom. 13:4, <strong>r.</strong> Heb. 11:32–34, <strong>t.</strong> Matt. 25:42–43, <strong>u.</strong> Matt. 5:22, <strong>w.</strong> 1 John 3:15; Lev. 19:17, <strong>x.</strong> Prov. 14:30, <strong>y.</strong> Rom. 12:19, <strong>z.</strong> Eph. 4:31</p></div>
+<p><strong>a.</strong> Matt. 6:31, 34, <strong>g.</strong> Rom. 13:10, <strong>h.</strong> Luke 10:33-34, <strong>i.</strong> Col. 3:12-13, <strong>l.</strong> 1 Pet. 3:8-11; 1 Cor. 4:12-13; Prov. 15:1; Judg. 8:1-3, <strong>m.</strong> Matt. 5:24; Eph. 4:2, 32; Rom. 12:17, 20-21; 1 Thess. 5:14; Matt. 25:35-36; Prov. 31:8-9; Job 31:19-20; Isa. 58:7, <strong>o.</strong> Acts 16:28, <strong>p.</strong> Gen. 9:6, <strong>q.</strong> Num. 35:31, 33; Rom. 13:4, <strong>r.</strong> Heb. 11:32-34, <strong>t.</strong> Matt. 25:42-43, <strong>u.</strong> Matt. 5:22, <strong>w.</strong> 1 John 3:15; Lev. 19:17, <strong>x.</strong> Prov. 14:30, <strong>y.</strong> Rom. 12:19, <strong>z.</strong> Eph. 4:31</p></div>
 </details>
 
 
@@ -1567,7 +1567,7 @@ Answer: The duties required in the seventh commandment are, chastity in body, mi
 <details class="scripture-proofs" id="wlc-q138-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>b.</strong> Luke 21:34; Rom. 13:13, <strong>d.</strong> Isa. 5:12, <strong>e.</strong> Prov. 15:1; Prov. 12:18, <strong>f.</strong> Isa. 3:15, <strong>g.</strong> Gal. 5:15; Prov. 23:29, <strong>h.</strong> Num. 35:16–17, <strong>i.</strong> Deut. 5:18, <strong>l.</strong> 1 Thess. 4:4–5, <strong>m.</strong> Eph. 4:29; Col. 4:6, <strong>n.</strong> 1 Pet. 3:2, <strong>o.</strong> 1 Cor. 7:2–5, 34–36, <strong>p.</strong> Matt. 5:28; Job 31:1, <strong>q.</strong> Acts 24:24–25, <strong>r.</strong> Prov. 2:16–20, <strong>s.</strong> 1 Tim. 2:9, <strong>t.</strong> 1 Cor. 7:2, 9</p></div>
+<p><strong>b.</strong> Luke 21:34; Rom. 13:13, <strong>d.</strong> Isa. 5:12, <strong>e.</strong> Prov. 15:1; Prov. 12:18, <strong>f.</strong> Isa. 3:15, <strong>g.</strong> Gal. 5:15; Prov. 23:29, <strong>h.</strong> Num. 35:16-17, <strong>i.</strong> Deut. 5:18, <strong>l.</strong> 1 Thess. 4:4-5, <strong>m.</strong> Eph. 4:29; Col. 4:6, <strong>n.</strong> 1 Pet. 3:2, <strong>o.</strong> 1 Cor. 7:2-5, 34-36, <strong>p.</strong> Matt. 5:28; Job 31:1, <strong>q.</strong> Acts 24:24-25, <strong>r.</strong> Prov. 2:16-20, <strong>s.</strong> 1 Tim. 2:9, <strong>t.</strong> 1 Cor. 7:2, 9</p></div>
 </details>
 
 
@@ -1578,7 +1578,7 @@ Answer: The sins forbidden in the seventh commandment, besides the neglect of th
 <details class="scripture-proofs" id="wlc-q139-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Heb. 13:4; Eph. 5:5; Gal. 5:19, <strong>b.</strong> 2 Sam. 13:14; 1 Cor. 5:1; Mark 6:18, <strong>c.</strong> Rom. 1:24, 26–27; Lev. 20:15–16, <strong>d.</strong> Matt. 5:28; Matt. 15:19, <strong>e.</strong> Eph. 5:3–4; Prov. 7:5, 21–22, <strong>f.</strong> Isa. 3:16; 2 Pet. 2:14, <strong>g.</strong> Prov. 7:10, 13, <strong>h.</strong> 1 Tim. 4:3, <strong>i.</strong> Mark 6:18; Mal. 2:11–12; Lev. 18:1–21; 1 Kings 15:12; 2 Kings 23:7; Lev. 19:29; Jer. 5:7; Deut. 23:17–18; Prov. 7:24–27, <strong>l.</strong> Matt. 19:10–11, <strong>m.</strong> 1 Cor. 7:7–9; Gen. 38:26, <strong>n.</strong> Mal. 2:14–15; Matt. 19:5, <strong>o.</strong> Mal. 2:16; Matt. 5:32; Matt. 19:8–9, <strong>p.</strong> 1 Cor. 7:12–13, <strong>q.</strong> Ezek. 16:49; Prov. 23:30–33, <strong>r.</strong> Gen. 39:19; Prov. 5:8, <strong>s.</strong> Eph. 5:4; Rom. 13:13; 1 Pet. 4:3; Ezek. 23:14–16; Isa. 3:16; Mark 6:22, <strong>t.</strong> 2 Kings 9:30; Jer. 4:30; Ezek. 23:40, <strong>u.</strong> Prov. 5:19–20, <strong>w.</strong> 1 Pet. 3:7; 1 Cor. 7:5, <strong>x.</strong> Prov. 31:11, 27–28, <strong>y.</strong> Prov. 5:8; Gen. 39:8–10, <strong>z.</strong> Prov. 5:7; Prov. 4:23, 27</p></div>
+<p><strong>a.</strong> Heb. 13:4; Eph. 5:5; Gal. 5:19, <strong>b.</strong> 2 Sam. 13:14; 1 Cor. 5:1; Mark 6:18, <strong>c.</strong> Rom. 1:24, 26-27; Lev. 20:15-16, <strong>d.</strong> Matt. 5:28; Matt. 15:19, <strong>e.</strong> Eph. 5:3-4; Prov. 7:5, 21-22, <strong>f.</strong> Isa. 3:16; 2 Pet. 2:14, <strong>g.</strong> Prov. 7:10, 13, <strong>h.</strong> 1 Tim. 4:3, <strong>i.</strong> Mark 6:18; Mal. 2:11-12; Lev. 18:1-21; 1 Kings 15:12; 2 Kings 23:7; Lev. 19:29; Jer. 5:7; Deut. 23:17-18; Prov. 7:24-27, <strong>l.</strong> Matt. 19:10-11, <strong>m.</strong> 1 Cor. 7:7-9; Gen. 38:26, <strong>n.</strong> Mal. 2:14-15; Matt. 19:5, <strong>o.</strong> Mal. 2:16; Matt. 5:32; Matt. 19:8-9, <strong>p.</strong> 1 Cor. 7:12-13, <strong>q.</strong> Ezek. 16:49; Prov. 23:30-33, <strong>r.</strong> Gen. 39:19; Prov. 5:8, <strong>s.</strong> Eph. 5:4; Rom. 13:13; 1 Pet. 4:3; Ezek. 23:14-16; Isa. 3:16; Mark 6:22, <strong>t.</strong> 2 Kings 9:30; Jer. 4:30; Ezek. 23:40, <strong>u.</strong> Prov. 5:19-20, <strong>w.</strong> 1 Pet. 3:7; 1 Cor. 7:5, <strong>x.</strong> Prov. 31:11, 27-28, <strong>y.</strong> Prov. 5:8; Gen. 39:8-10, <strong>z.</strong> Prov. 5:7; Prov. 4:23, 27</p></div>
 </details>
 
 
@@ -1601,7 +1601,7 @@ Answer: The duties required in the eighth commandment are, truth, faithfulness, 
 <details class="scripture-proofs" id="wlc-q141-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> 1 Tim. 6:6–9, <strong>u.</strong> Deut. 5:19, <strong>w.</strong> Ps. 15:2, 4; Mic. 6:8; Zech. 8:16–17; Zech. 7:4, 10, <strong>x.</strong> Rom. 13:7, <strong>y.</strong> Lev. 6:2–5; Luke 19:8, <strong>z.</strong> Luke 6:30, 38; 1 John 3:17; Eph. 4:28; Gal. 6:10</p></div>
+<p><strong>a.</strong> 1 Tim. 6:6-9, <strong>u.</strong> Deut. 5:19, <strong>w.</strong> Ps. 15:2, 4; Mic. 6:8; Zech. 8:16-17; Zech. 7:4, 10, <strong>x.</strong> Rom. 13:7, <strong>y.</strong> Lev. 6:2-5; Luke 19:8, <strong>z.</strong> Luke 6:30, 38; 1 John 3:17; Eph. 4:28; Gal. 6:10</p></div>
 </details>
 
 
@@ -1612,7 +1612,7 @@ Answer: The sins forbidden in the eighth commandment, besides the neglect of the
 <details class="scripture-proofs" id="wlc-q142-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Isa. 5:8; Mic. 2:2, <strong>b.</strong> Prov. 11:26, <strong>c.</strong> Acts 19:19, <strong>d.</strong> Prov. 21:6; Job 20:19, <strong>e.</strong> Luke 12:15, <strong>f.</strong> 1 Tim. 6:5; Col. 3:2; 1 John 2:15–16; Prov. 23:5; Ps. 62:10, <strong>g.</strong> Matt. 6:25, 31, 34, <strong>h.</strong> Prov. 11:15; Prov. 6:1–6, <strong>i.</strong> Lev. 25:35; Phil. 2:4; Deut. 22:1–4; Gen. 47:14, 20; Matt. 22:39, <strong>l.</strong> Eph. 4:28, <strong>m.</strong> Ps. 62:10, <strong>n.</strong> 1 Tim. 1:10, <strong>o.</strong> Prov. 29:24; Ps. 50:18, <strong>p.</strong> 1 Thess. 4:6; Lev. 19:13, <strong>q.</strong> Prov. 11:1; Prov. 20:10, <strong>r.</strong> Deut. 19:14; Prov. 23:10, <strong>s.</strong> Amos 8:5; Ps. 37:21, <strong>t.</strong> Luke 16:10–12, <strong>u.</strong> Ezek. 22:29; Lev. 25:17, <strong>w.</strong> Matt. 23:25, <strong>x.</strong> Ps. 15:5, <strong>y.</strong> Job 15:34, <strong>z.</strong> 1 Cor. 6:6–8; Prov. 3:29–30</p></div>
+<p><strong>a.</strong> Isa. 5:8; Mic. 2:2, <strong>b.</strong> Prov. 11:26, <strong>c.</strong> Acts 19:19, <strong>d.</strong> Prov. 21:6; Job 20:19, <strong>e.</strong> Luke 12:15, <strong>f.</strong> 1 Tim. 6:5; Col. 3:2; 1 John 2:15-16; Prov. 23:5; Ps. 62:10, <strong>g.</strong> Matt. 6:25, 31, 34, <strong>h.</strong> Prov. 11:15; Prov. 6:1-6, <strong>i.</strong> Lev. 25:35; Phil. 2:4; Deut. 22:1-4; Gen. 47:14, 20; Matt. 22:39, <strong>l.</strong> Eph. 4:28, <strong>m.</strong> Ps. 62:10, <strong>n.</strong> 1 Tim. 1:10, <strong>o.</strong> Prov. 29:24; Ps. 50:18, <strong>p.</strong> 1 Thess. 4:6; Lev. 19:13, <strong>q.</strong> Prov. 11:1; Prov. 20:10, <strong>r.</strong> Deut. 19:14; Prov. 23:10, <strong>s.</strong> Amos 8:5; Ps. 37:21, <strong>t.</strong> Luke 16:10-12, <strong>u.</strong> Ezek. 22:29; Lev. 25:17, <strong>w.</strong> Matt. 23:25, <strong>x.</strong> Ps. 15:5, <strong>y.</strong> Job 15:34, <strong>z.</strong> 1 Cor. 6:6-8; Prov. 3:29-30</p></div>
 </details>
 
 
@@ -1635,7 +1635,7 @@ Answer: The duties required in the ninth commandment are, the preserving and pro
 <details class="scripture-proofs" id="wlc-q144-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>h.</strong> Ps. 73:3; Ps. 37:1, 7, <strong>i.</strong> 2 Thess. 3:10–11; Prov. 18:9; Prov. 21:17; Prov. 23:20–21; Prov. 28:19; 1 Tim. 4:3–5; 1 Tim. 5:8, <strong>m.</strong> Deut. 5:20, <strong>n.</strong> Zech. 8:16; Eph. 4:25, <strong>p.</strong> Prov. 31:8–9, <strong>q.</strong> Ps. 15:2, <strong>r.</strong> 2 Chron. 19:9, <strong>s.</strong> 1 Sam. 19:4–5, <strong>t.</strong> Josh. 7:19, <strong>u.</strong> 2 Sam. 14:18; Acts 20:27, <strong>w.</strong> Lev. 19:15; Prov. 14:5, 25, <strong>x.</strong> 2 Cor. 1:17–18; Eph. 4:25; Col. 3:9, <strong>y.</strong> Heb. 6:9; 1 Cor. 13:7, <strong>z.</strong> Rom. 1:8</p></div>
+<p><strong>h.</strong> Ps. 73:3; Ps. 37:1, 7, <strong>i.</strong> 2 Thess. 3:10-11; Prov. 18:9; Prov. 21:17; Prov. 23:20-21; Prov. 28:19; 1 Tim. 4:3-5; 1 Tim. 5:8, <strong>m.</strong> Deut. 5:20, <strong>n.</strong> Zech. 8:16; Eph. 4:25, <strong>p.</strong> Prov. 31:8-9, <strong>q.</strong> Ps. 15:2, <strong>r.</strong> 2 Chron. 19:9, <strong>s.</strong> 1 Sam. 19:4-5, <strong>t.</strong> Josh. 7:19, <strong>u.</strong> 2 Sam. 14:18; Acts 20:27, <strong>w.</strong> Lev. 19:15; Prov. 14:5, 25, <strong>x.</strong> 2 Cor. 1:17-18; Eph. 4:25; Col. 3:9, <strong>y.</strong> Heb. 6:9; 1 Cor. 13:7, <strong>z.</strong> Rom. 1:8</p></div>
 </details>
 
 
@@ -1646,7 +1646,7 @@ Answer: The sins forbidden in the ninth commandment are, all prejudicing <span c
 <details class="scripture-proofs" id="wlc-q145-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> 1 Sam. 22:9–10; Ps. 52:1–5, <strong>b.</strong> Ps. 56:5; Matt. 26:60–61; John 2:19, <strong>c.</strong> Gen. 3:5; Gen. 26:7, 9, <strong>d.</strong> Isa. 59:13, <strong>e.</strong> Col. 3:9; Lev. 19:11, <strong>f.</strong> Ps. 50:20, <strong>g.</strong> Ps. 15:3, <strong>h.</strong> Jer. 38:4, <strong>i.</strong> Lev. 19:16; Rom. 1:29–30, <strong>l.</strong> Gen. 21:9; Gal. 4:29, <strong>m.</strong> 1 Cor. 6:10; Matt. 7:1, <strong>n.</strong> Luke 3:14; 1 Sam. 17:28; 2 Sam. 16:3, <strong>o.</strong> Lev. 19:15; Hab. 1:4, <strong>p.</strong> Prov. 19:5; Prov. 6:16, 19, <strong>q.</strong> Acts 6:13, <strong>r.</strong> Jer. 9:3, 5; Ps. 12:3–4; Acts 24:2, 5; Ps. 52:1–4, <strong>s.</strong> Prov. 17:15; 1 Kings 21:9–14, <strong>t.</strong> Isa. 5:23, <strong>u.</strong> 1 Kings 21:8, <strong>w.</strong> Lev. 5:1; Acts 5:3; Deut. 13:8; 2 Tim. 4:16, <strong>x.</strong> 1 Kings 1:6; Lev. 19:17, <strong>y.</strong> Isa. 59:4, <strong>z.</strong> Prov. 29:11</p></div>
+<p><strong>a.</strong> 1 Sam. 22:9-10; Ps. 52:1-5, <strong>b.</strong> Ps. 56:5; Matt. 26:60-61; John 2:19, <strong>c.</strong> Gen. 3:5; Gen. 26:7, 9, <strong>d.</strong> Isa. 59:13, <strong>e.</strong> Col. 3:9; Lev. 19:11, <strong>f.</strong> Ps. 50:20, <strong>g.</strong> Ps. 15:3, <strong>h.</strong> Jer. 38:4, <strong>i.</strong> Lev. 19:16; Rom. 1:29-30, <strong>l.</strong> Gen. 21:9; Gal. 4:29, <strong>m.</strong> 1 Cor. 6:10; Matt. 7:1, <strong>n.</strong> Luke 3:14; 1 Sam. 17:28; 2 Sam. 16:3, <strong>o.</strong> Lev. 19:15; Hab. 1:4, <strong>p.</strong> Prov. 19:5; Prov. 6:16, 19, <strong>q.</strong> Acts 6:13, <strong>r.</strong> Jer. 9:3, 5; Ps. 12:3-4; Acts 24:2, 5; Ps. 52:1-4, <strong>s.</strong> Prov. 17:15; 1 Kings 21:9-14, <strong>t.</strong> Isa. 5:23, <strong>u.</strong> 1 Kings 21:8, <strong>w.</strong> Lev. 5:1; Acts 5:3; Deut. 13:8; 2 Tim. 4:16, <strong>x.</strong> 1 Kings 1:6; Lev. 19:17, <strong>y.</strong> Isa. 59:4, <strong>z.</strong> Prov. 29:11</p></div>
 </details>
 
 
@@ -1681,7 +1681,7 @@ Answer: The sins forbidden in the tenth commandment are, discontentment with our
 <details class="scripture-proofs" id="wlc-q148-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>m.</strong> Deut. 5:21, <strong>n.</strong> Heb. 13:5; 1 Tim. 6:6; Phil. 4:11, <strong>o.</strong> Job 31:29; Rom. 12:15; Ps. 122:7–9; 1 Tim. 1:5; Est. 10:3; 1 Cor. 13:4–7, <strong>p.</strong> 1 Cor. 10:10; 1 Kings 21:4; Est. 5:13</p></div>
+<p><strong>m.</strong> Deut. 5:21, <strong>n.</strong> Heb. 13:5; 1 Tim. 6:6; Phil. 4:11, <strong>o.</strong> Job 31:29; Rom. 12:15; Ps. 122:7-9; 1 Tim. 1:5; Est. 10:3; 1 Cor. 13:4-7, <strong>p.</strong> 1 Cor. 10:10; 1 Kings 21:4; Est. 5:13</p></div>
 </details>
 
 
@@ -1692,7 +1692,7 @@ Answer: No man is able, either of himself,<sup class="proof-marker">t</sup> or b
 <details class="scripture-proofs" id="wlc-q149-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>q.</strong> Gal. 5:26, <strong>r.</strong> Ps. 112:9–10; Neh. 2:10, <strong>s.</strong> Rom. 7:7–8; Rom. 13:9; Col. 3:5; Deut. 5:21, <strong>t.</strong> John 15:5; Rom. 8:3, <strong>u.</strong> 1 John 1:8, 10; Gal. 5:17; Rom. 7:18–19, <strong>w.</strong> Gen. 6:5; Gen. 8:21</p></div>
+<p><strong>q.</strong> Gal. 5:26, <strong>r.</strong> Ps. 112:9-10; Neh. 2:10, <strong>s.</strong> Rom. 7:7-8; Rom. 13:9; Col. 3:5; Deut. 5:21, <strong>t.</strong> John 15:5; Rom. 8:3, <strong>u.</strong> 1 John 1:8, 10; Gal. 5:17; Rom. 7:18-19, <strong>w.</strong> Gen. 6:5; Gen. 8:21</p></div>
 </details>
 
 
@@ -1719,7 +1719,7 @@ Answer: Sins receive their aggravations,
 <details class="scripture-proofs" id="wlc-q151-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Col. 3:5; 1 Tim. 6:10; Prov. 5:8–12; Prov. 6:32–33; Josh. 7:21, <strong>b.</strong> Matt. 5:22; Mic. 2:1, <strong>c.</strong> Matt. 18:7; Rom. 2:23–24, <strong>d.</strong> 2 Kings 5:26, <strong>e.</strong> Jer. 7:10; Isa. 26:10, <strong>f.</strong> Ezek. 23:37–39, <strong>g.</strong> Isa. 58:3–5; Num. 25:6–7, <strong>h.</strong> 1 Cor. 11:20–21; Jer. 7:8–10, <strong>i.</strong> Prov. 7:14–15, <strong>l.</strong> Matt. 18:17, <strong>m.</strong> Prov. 27:22; Prov. 23:35, <strong>n.</strong> Ps. 78:34–37; Jer. 2:20; Jer. 13:5–6, 20–21, <strong>o.</strong> Prov. 20:25, <strong>p.</strong> Lev. 26:25, <strong>q.</strong> Prov. 2:17; Ezek. 7:18–19, <strong>r.</strong> Ps. 36:4, <strong>s.</strong> Jer. 6:16, <strong>t.</strong> Num. 15:30, <strong>u.</strong> Jer. 3:3; Prov. 7:13, <strong>w.</strong> Ps. 52:1, <strong>x.</strong> Num. 14:22; Zech. 7:11–12; Prov. 2:14; Isa. 57:17; Jer. 34:8–11, <strong>y.</strong> Prov. 6:30–33, <strong>z.</strong> Ezra 9:10–12; 1 Kings 11:9–10</p></div>
+<p><strong>a.</strong> Col. 3:5; 1 Tim. 6:10; Prov. 5:8-12; Prov. 6:32-33; Josh. 7:21, <strong>b.</strong> Matt. 5:22; Mic. 2:1, <strong>c.</strong> Matt. 18:7; Rom. 2:23-24, <strong>d.</strong> 2 Kings 5:26, <strong>e.</strong> Jer. 7:10; Isa. 26:10, <strong>f.</strong> Ezek. 23:37-39, <strong>g.</strong> Isa. 58:3-5; Num. 25:6-7, <strong>h.</strong> 1 Cor. 11:20-21; Jer. 7:8-10, <strong>i.</strong> Prov. 7:14-15, <strong>l.</strong> Matt. 18:17, <strong>m.</strong> Prov. 27:22; Prov. 23:35, <strong>n.</strong> Ps. 78:34-37; Jer. 2:20; Jer. 13:5-6, 20-21, <strong>o.</strong> Prov. 20:25, <strong>p.</strong> Lev. 26:25, <strong>q.</strong> Prov. 2:17; Ezek. 7:18-19, <strong>r.</strong> Ps. 36:4, <strong>s.</strong> Jer. 6:16, <strong>t.</strong> Num. 15:30, <strong>u.</strong> Jer. 3:3; Prov. 7:13, <strong>w.</strong> Ps. 52:1, <strong>x.</strong> Num. 14:22; Zech. 7:11-12; Prov. 2:14; Isa. 57:17; Jer. 34:8-11, <strong>y.</strong> Prov. 6:30-33, <strong>z.</strong> Ezra 9:10-12; 1 Kings 11:9-10</p></div>
 </details>
 
 
@@ -1730,7 +1730,7 @@ Answer: Every sin, even the least, being against the sovereignty,<sup class="pro
 <details class="scripture-proofs" id="wlc-q152-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> 2 Sam. 16:22; 1 Sam. 2:22–24, <strong>o.</strong> Hab. 1:13; Lev. 10:3; Lev. 11:44–45, <strong>p.</strong> 1 John 3:4; Rom. 7:12, <strong>q.</strong> Eph. 5:6; Gal. 3:10</p></div>
+<p><strong>l.</strong> 2 Sam. 16:22; 1 Sam. 2:22-24, <strong>o.</strong> Hab. 1:13; Lev. 10:3; Lev. 11:44-45, <strong>p.</strong> 1 John 3:4; Rom. 7:12, <strong>q.</strong> Eph. 5:6; Gal. 3:10</p></div>
 </details>
 
 
@@ -1741,7 +1741,7 @@ Answer: That we may escape the wrath and curse of God due to us by reason of the
 <details class="scripture-proofs" id="wlc-q153-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>r.</strong> Lam. 3:39; Deut. 28:15–68, <strong>s.</strong> Matt. 25:41, <strong>t.</strong> Heb. 9:22; 1 Pet. 1:18–19, <strong>u.</strong> Acts 20:21; Matt. 3:7–8; Luke 13:3, 5; Acts 16:30–31; John 3:16, 18, <strong>w.</strong> Prov. 2:1–5; Prov. 8:33–36</p></div>
+<p><strong>r.</strong> Lam. 3:39; Deut. 28:15-68, <strong>s.</strong> Matt. 25:41, <strong>t.</strong> Heb. 9:22; 1 Pet. 1:18-19, <strong>u.</strong> Acts 20:21; Matt. 3:7-8; Luke 13:3, 5; Acts 16:30-31; John 3:16, 18, <strong>w.</strong> Prov. 2:1-5; Prov. 8:33-36</p></div>
 </details>
 
 
@@ -1764,7 +1764,7 @@ Answer: The Spirit of God <span class="v-const">maketh</span><span class="v-mode
 <details class="scripture-proofs" id="wlc-q155-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Acts 2:37, 41; Acts 8:27–38, <strong>b.</strong> 2 Cor. 3:18; Col. 1:27, <strong>c.</strong> 2 Cor. 10:4–6; Rom. 6:17–18, <strong>x.</strong> Matt. 28:19–20; Acts 2:42, 46–47, <strong>y.</strong> Neh. 8:8; Acts 26:18; Ps. 19:8, <strong>z.</strong> 1 Cor. 14:24–25; 2 Chron. 34:18–19, 26–28</p></div>
+<p><strong>a.</strong> Acts 2:37, 41; Acts 8:27-38, <strong>b.</strong> 2 Cor. 3:18; Col. 1:27, <strong>c.</strong> 2 Cor. 10:4-6; Rom. 6:17-18, <strong>x.</strong> Matt. 28:19-20; Acts 2:42, 46-47, <strong>y.</strong> Neh. 8:8; Acts 26:18; Ps. 19:8, <strong>z.</strong> 1 Cor. 14:24-25; 2 Chron. 34:18-19, 26-28</p></div>
 </details>
 
 
@@ -1775,7 +1775,7 @@ Answer: Although all are not to be permitted to read the <span class="v-const">w
 <details class="scripture-proofs" id="wlc-q156-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>d.</strong> Eph. 6:16–17; Col. 1:28; Ps. 19:11; Matt. 4:4, 7, 10; 1 Cor. 10:11, <strong>e.</strong> Eph. 4:11–12; Acts 20:32; 2 Tim. 3:15–17, <strong>f.</strong> Rom. 16:25; 1 Thess. 3:2, 10–11, 13; Rom. 15:4, <strong>g.</strong> Deut. 31:9, 11–13; Neh. 8:2–3, <strong>h.</strong> Deut. 17:19; Rev. 1:3; John 5:39; Isa. 34:16</p></div>
+<p><strong>d.</strong> Eph. 6:16-17; Col. 1:28; Ps. 19:11; Matt. 4:4, 7, 10; 1 Cor. 10:11, <strong>e.</strong> Eph. 4:11-12; Acts 20:32; 2 Tim. 3:15-17, <strong>f.</strong> Rom. 16:25; 1 Thess. 3:2, 10-11, 13; Rom. 15:4, <strong>g.</strong> Deut. 31:9, 11-13; Neh. 8:2-3, <strong>h.</strong> Deut. 17:19; Rev. 1:3; John 5:39; Isa. 34:16</p></div>
 </details>
 
 
@@ -1786,7 +1786,7 @@ Answer: The <span class="v-const">holy</span><span class="v-modern">Holy</span> 
 <details class="scripture-proofs" id="wlc-q157-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>i.</strong> Deut. 6:6–9; Gen. 18:17, 19; Ps. 78:5–7; 1 Cor. 14:6, 9, 11–12, 15–16, 24, 27–28; Neh. 8:8, <strong>l.</strong> Ps. 119:97; Ps. 19:10; 2 Chron. 34:27, <strong>m.</strong> 2 Pet. 1:19–21; Matt. 4:4; 1 Thess. 2:13; Mark 7:13, <strong>n.</strong> Luke 24:45; 2 Cor. 3:13–16, <strong>o.</strong> Deut. 17:10, 20, <strong>p.</strong> Acts 17:11, <strong>q.</strong> Acts 8:30, 34; Luke 10:26–28, <strong>r.</strong> Ps. 1:2; Ps. 119:97, <strong>s.</strong> 2 Chron. 34:21</p></div>
+<p><strong>i.</strong> Deut. 6:6-9; Gen. 18:17, 19; Ps. 78:5-7; 1 Cor. 14:6, 9, 11-12, 15-16, 24, 27-28; Neh. 8:8, <strong>l.</strong> Ps. 119:97; Ps. 19:10; 2 Chron. 34:27, <strong>m.</strong> 2 Pet. 1:19-21; Matt. 4:4; 1 Thess. 2:13; Mark 7:13, <strong>n.</strong> Luke 24:45; 2 Cor. 3:13-16, <strong>o.</strong> Deut. 17:10, 20, <strong>p.</strong> Acts 17:11, <strong>q.</strong> Acts 8:30, 34; Luke 10:26-28, <strong>r.</strong> Ps. 1:2; Ps. 119:97, <strong>s.</strong> 2 Chron. 34:21</p></div>
 </details>
 
 
@@ -1797,7 +1797,7 @@ Answer: The Word of God is to be preached only by <span class="v-const">such as<
 <details class="scripture-proofs" id="wlc-q158-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>t.</strong> Prov. 3:5; Deut. 33:3; Matt. 16:24; Luke 9:23; Gal. 1:15–16, <strong>u.</strong> Prov. 2:1–6; Ps. 119:18; Neh. 8:6, 8, <strong>w.</strong> 1 Tim. 3:2, 6; Eph. 4:8–11; Mal. 2:7; 2 Cor. 3:6; 2 Tim. 2:2, <strong>x.</strong> Jer. 14:15; Rom. 10:15; Heb. 5:4; 1 Cor. 12:28–29; 1 Tim. 3:10</p></div>
+<p><strong>t.</strong> Prov. 3:5; Deut. 33:3; Matt. 16:24; Luke 9:23; Gal. 1:15-16, <strong>u.</strong> Prov. 2:1-6; Ps. 119:18; Neh. 8:6, 8, <strong>w.</strong> 1 Tim. 3:2, 6; Eph. 4:8-11; Mal. 2:7; 2 Cor. 3:6; 2 Tim. 2:2, <strong>x.</strong> Jer. 14:15; Rom. 10:15; Heb. 5:4; 1 Cor. 12:28-29; 1 Tim. 3:10</p></div>
 </details>
 
 
@@ -1808,7 +1808,7 @@ Answer: <span class="v-const">They that</span><span class="v-modern">Those who</
 <details class="scripture-proofs" id="wlc-q159-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> 2 Tim. 4:2, <strong>b.</strong> 1 Cor. 14:9, <strong>c.</strong> 1 Cor. 2:4, <strong>d.</strong> Jer. 23:28; 1 Cor. 4:1–2, <strong>e.</strong> Acts 20:27, <strong>f.</strong> Col. 1:28; 2 Tim. 2:15, <strong>g.</strong> 1 Cor. 3:2; Heb. 5:12–14; Luke 12:42, <strong>h.</strong> Acts 18:25; Ps. 119:139; 2 Tim. 4:5, <strong>i.</strong> 2 Cor. 5:13–14; Phil. 1:15–17; Col. 4:12; 2 Cor. 12:15, <strong>l.</strong> 2 Cor. 2:17; 2 Cor. 4:2, <strong>m.</strong> 1 Thess. 2:4–6; John 7:18, <strong>n.</strong> 1 Cor. 9:19–22, <strong>o.</strong> 2 Cor. 12:19; Eph. 4:12, <strong>p.</strong> 1 Tim. 4:16; Acts 26:16–18, <strong>z.</strong> Acts 18:25</p></div>
+<p><strong>a.</strong> 2 Tim. 4:2, <strong>b.</strong> 1 Cor. 14:9, <strong>c.</strong> 1 Cor. 2:4, <strong>d.</strong> Jer. 23:28; 1 Cor. 4:1-2, <strong>e.</strong> Acts 20:27, <strong>f.</strong> Col. 1:28; 2 Tim. 2:15, <strong>g.</strong> 1 Cor. 3:2; Heb. 5:12-14; Luke 12:42, <strong>h.</strong> Acts 18:25; Ps. 119:139; 2 Tim. 4:5, <strong>i.</strong> 2 Cor. 5:13-14; Phil. 1:15-17; Col. 4:12; 2 Cor. 12:15, <strong>l.</strong> 2 Cor. 2:17; 2 Cor. 4:2, <strong>m.</strong> 1 Thess. 2:4-6; John 7:18, <strong>n.</strong> 1 Cor. 9:19-22, <strong>o.</strong> 2 Cor. 12:19; Eph. 4:12, <strong>p.</strong> 1 Tim. 4:16; Acts 26:16-18, <strong>z.</strong> Acts 18:25</p></div>
 </details>
 
 
@@ -1819,7 +1819,7 @@ Answer: It is required of those that hear the <span class="v-const">word</span><
 <details class="scripture-proofs" id="wlc-q160-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Luke 9:44; Heb. 2:1, <strong>b.</strong> Luke 24:14; Deut. 6:6–7, <strong>q.</strong> Prov. 8:34, <strong>r.</strong> 1 Pet. 2:1–2; Luke 8:18, <strong>s.</strong> Ps. 119:18; Eph. 6:18–19, <strong>t.</strong> Acts 17:11, <strong>u.</strong> Heb. 4:2, <strong>w.</strong> 2 Thess. 2:10, <strong>y.</strong> Acts 17:11, <strong>z.</strong> 1 Thess. 2:13</p></div>
+<p><strong>a.</strong> Luke 9:44; Heb. 2:1, <strong>b.</strong> Luke 24:14; Deut. 6:6-7, <strong>q.</strong> Prov. 8:34, <strong>r.</strong> 1 Pet. 2:1-2; Luke 8:18, <strong>s.</strong> Ps. 119:18; Eph. 6:18-19, <strong>t.</strong> Acts 17:11, <strong>u.</strong> Heb. 4:2, <strong>w.</strong> 2 Thess. 2:10, <strong>y.</strong> Acts 17:11, <strong>z.</strong> 1 Thess. 2:13</p></div>
 </details>
 
 
@@ -1842,7 +1842,7 @@ Answer: A sacrament is <span class="v-const">an</span><span class="v-modern">a</
 <details class="scripture-proofs" id="wlc-q162-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>c.</strong> Prov. 2:1; Ps. 119:11, <strong>d.</strong> Luke 8:15, <strong>e.</strong> 1 Pet. 3:21; Acts 8:13, 23; 1 Cor. 3:5–7; 1 Cor. 1:12–17; 1 Cor. 12:13; 1 Cor. 6:11, <strong>f.</strong> Gen. 17:7, 10, <strong>g.</strong> Rom. 4:11; 1 Cor. 11:24–25, <strong>h.</strong> Rom. 15:8; Rom. 9:8; Gal. 3:27, 29, <strong>i.</strong> Acts 2:38; 1 Cor. 10:16; Rom. 4:11; Gal. 3:27, <strong>l.</strong> Rom. 6:3–4; 1 Cor. 10:21, <strong>m.</strong> Eph. 4:2–5</p></div>
+<p><strong>c.</strong> Prov. 2:1; Ps. 119:11, <strong>d.</strong> Luke 8:15, <strong>e.</strong> 1 Pet. 3:21; Acts 8:13, 23; 1 Cor. 3:5-7; 1 Cor. 1:12-17; 1 Cor. 12:13; 1 Cor. 6:11, <strong>f.</strong> Gen. 17:7, 10, <strong>g.</strong> Rom. 4:11; 1 Cor. 11:24-25, <strong>h.</strong> Rom. 15:8; Rom. 9:8; Gal. 3:27, 29, <strong>i.</strong> Acts 2:38; 1 Cor. 10:16; Rom. 4:11; Gal. 3:27, <strong>l.</strong> Rom. 6:3-4; 1 Cor. 10:21, <strong>m.</strong> Eph. 4:2-5</p></div>
 </details>
 
 
@@ -1877,7 +1877,7 @@ Answer: Baptism is a sacrament of the <span class="v-const">New Testament, where
 <details class="scripture-proofs" id="wlc-q165-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>n.</strong> Eph. 2:11–12; Gen. 34:14, <strong>o.</strong> Matt. 3:11; 1 Pet. 3:21; Deut. 10:16; Jer. 4:4, <strong>p.</strong> Matt. 28:19; 1 Cor. 11:20, 23; Matt. 26:26–28</p></div>
+<p><strong>n.</strong> Eph. 2:11-12; Gen. 34:14, <strong>o.</strong> Matt. 3:11; 1 Pet. 3:21; Deut. 10:16; Jer. 4:4, <strong>p.</strong> Matt. 28:19; 1 Cor. 11:20, 23; Matt. 26:26-28</p></div>
 </details>
 
 
@@ -1888,7 +1888,7 @@ Answer: Baptism is not to be administered to any that are out of the visible chu
 <details class="scripture-proofs" id="wlc-q166-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>q.</strong> Matt. 28:19, <strong>r.</strong> Gal. 3:27; Rom. 6:3, <strong>s.</strong> Mark 1:4; Rev. 1:5; Acts 2:38; Acts 22:16; 1 Pet. 3:21, <strong>t.</strong> Eph. 5:26; Acts 2:38, <strong>u.</strong> Gal. 3:26–27, <strong>w.</strong> 1 Cor. 15:29; Rom. 6:5, <strong>x.</strong> 1 Cor. 12:13; Acts 2:41, <strong>y.</strong> Rom. 6:4; Acts 2:38–42, <strong>z.</strong> Acts 2:38–39, 41</p></div>
+<p><strong>q.</strong> Matt. 28:19, <strong>r.</strong> Gal. 3:27; Rom. 6:3, <strong>s.</strong> Mark 1:4; Rev. 1:5; Acts 2:38; Acts 22:16; 1 Pet. 3:21, <strong>t.</strong> Eph. 5:26; Acts 2:38, <strong>u.</strong> Gal. 3:26-27, <strong>w.</strong> 1 Cor. 15:29; Rom. 6:5, <strong>x.</strong> 1 Cor. 12:13; Acts 2:41, <strong>y.</strong> Rom. 6:4; Acts 2:38-42, <strong>z.</strong> Acts 2:38-39, 41</p></div>
 </details>
 
 
@@ -1899,7 +1899,7 @@ Answer: The needful but much neglected duty of improving our baptism, is to be p
 <details class="scripture-proofs" id="wlc-q167-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Col. 2:11–12; Acts 2:38–39; Rom. 4:11–12; 1 Cor. 7:14; Luke 18:15–16; Gen. 17:7–9; Gal. 3:9–14; Rom. 11:16, <strong>b.</strong> Col. 2:11–12; Rom. 6:4, 6, 11, <strong>c.</strong> Rom. 6:3–5; 1 Pet. 3:21, <strong>d.</strong> 1 Cor. 1:11–13; Rom. 6:2–3, <strong>e.</strong> Rom. 6:4–7, 22; 1 Pet. 3:21; Rom. 5:1–2; Jer. 33:8, <strong>f.</strong> Rom. 6:3–5</p></div>
+<p><strong>a.</strong> Col. 2:11-12; Acts 2:38-39; Rom. 4:11-12; 1 Cor. 7:14; Luke 18:15-16; Gen. 17:7-9; Gal. 3:9-14; Rom. 11:16, <strong>b.</strong> Col. 2:11-12; Rom. 6:4, 6, 11, <strong>c.</strong> Rom. 6:3-5; 1 Pet. 3:21, <strong>d.</strong> 1 Cor. 1:11-13; Rom. 6:2-3, <strong>e.</strong> Rom. 6:4-7, 22; 1 Pet. 3:21; Rom. 5:1-2; Jer. 33:8, <strong>f.</strong> Rom. 6:3-5</p></div>
 </details>
 
 
@@ -1910,7 +1910,7 @@ Answer: The Lord's <span class="v-const">supper</span><span class="v-modern">Sup
 <details class="scripture-proofs" id="wlc-q168-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>g.</strong> Gal. 3:26–27, <strong>h.</strong> Rom. 6:22, <strong>i.</strong> Acts 2:38; Gal. 2:20; Rev. 2:17; 1 Cor. 12:13, 25, <strong>l.</strong> Luke 22:20, <strong>m.</strong> Matt. 26:26–28; 1 Cor. 11:23–26, <strong>n.</strong> 1 Cor. 10:16, <strong>o.</strong> 1 Cor. 11:24</p></div>
+<p><strong>g.</strong> Gal. 3:26-27, <strong>h.</strong> Rom. 6:22, <strong>i.</strong> Acts 2:38; Gal. 2:20; Rev. 2:17; 1 Cor. 12:13, 25, <strong>l.</strong> Luke 22:20, <strong>m.</strong> Matt. 26:26-28; 1 Cor. 11:23-26, <strong>n.</strong> 1 Cor. 10:16, <strong>o.</strong> 1 Cor. 11:24</p></div>
 </details>
 
 
@@ -1933,7 +1933,7 @@ Answer: As the body and blood of Christ are not corporally or carnally present i
 <details class="scripture-proofs" id="wlc-q170-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>p.</strong> 1 Cor. 10:14–16, 21; Rom. 7:4, <strong>q.</strong> 1 Cor. 10:17, <strong>r.</strong> 1 Cor. 11:23–24; Matt. 26:26–28; Mark 14:22–24; Luke 22:19–20, <strong>s.</strong> Acts 3:21, <strong>t.</strong> Matt. 26:26, 28</p></div>
+<p><strong>p.</strong> 1 Cor. 10:14-16, 21; Rom. 7:4, <strong>q.</strong> 1 Cor. 10:17, <strong>r.</strong> 1 Cor. 11:23-24; Matt. 26:26-28; Mark 14:22-24; Luke 22:19-20, <strong>s.</strong> Acts 3:21, <strong>t.</strong> Matt. 26:26, 28</p></div>
 </details>
 
 
@@ -1944,7 +1944,7 @@ Answer: <span class="v-const">They that</span><span class="v-modern">Those who</
 <details class="scripture-proofs" id="wlc-q171-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> 1 Cor. 11:29, <strong>b.</strong> 2 Cor. 13:5; Matt. 26:28, <strong>c.</strong> Zech. 12:10; 1 Cor. 11:31, <strong>d.</strong> 1 Cor. 10:16–17; Acts 2:46–47, <strong>e.</strong> 1 Cor. 5:8; 1 Cor. 11:18, 20, <strong>f.</strong> Matt. 5:23–24, <strong>g.</strong> Isa. 55:1; John 7:37, <strong>h.</strong> 1 Cor. 5:7–8, <strong>i.</strong> 1 Cor. 11:25–26, 28; Heb. 10:21–22, 24; Ps. 26:6; 1 Cor. 11:24–25, <strong>l.</strong> 2 Chron. 30:18–19; Matt. 26:26, <strong>u.</strong> 1 Cor. 11:24–29; John 6:51, 53, <strong>w.</strong> 1 Cor. 10:16, <strong>x.</strong> 1 Cor. 11:28, <strong>y.</strong> 2 Cor. 13:5, <strong>z.</strong> 1 Cor. 5:7</p></div>
+<p><strong>a.</strong> 1 Cor. 11:29, <strong>b.</strong> 2 Cor. 13:5; Matt. 26:28, <strong>c.</strong> Zech. 12:10; 1 Cor. 11:31, <strong>d.</strong> 1 Cor. 10:16-17; Acts 2:46-47, <strong>e.</strong> 1 Cor. 5:8; 1 Cor. 11:18, 20, <strong>f.</strong> Matt. 5:23-24, <strong>g.</strong> Isa. 55:1; John 7:37, <strong>h.</strong> 1 Cor. 5:7-8, <strong>i.</strong> 1 Cor. 11:25-26, 28; Heb. 10:21-22, 24; Ps. 26:6; 1 Cor. 11:24-25, <strong>l.</strong> 2 Chron. 30:18-19; Matt. 26:26, <strong>u.</strong> 1 Cor. 11:24-29; John 6:51, 53, <strong>w.</strong> 1 Cor. 10:16, <strong>x.</strong> 1 Cor. 11:28, <strong>y.</strong> 2 Cor. 13:5, <strong>z.</strong> 1 Cor. 5:7</p></div>
 </details>
 
 
@@ -1955,7 +1955,7 @@ Answer: One who <span class="v-const">doubteth</span><span class="v-modern">doub
 <details class="scripture-proofs" id="wlc-q172-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>m.</strong> Isa. 50:10; 1 John 5:13; Ps. 77:1–4, 7–10; Jonah 2:4, <strong>n.</strong> Isa. 54:7–10; Matt. 5:3–4; Ps. 31:22; Ps. 73:13, 22–23, <strong>o.</strong> Phil. 3:8–9; Ps. 10:17; Ps. 42:1–2, 5, 11, <strong>p.</strong> 2 Tim. 2:19; Isa. 50:10; Ps. 66:18–20, <strong>q.</strong> Isa. 40:11, 29, 31; Matt. 11:28; Matt. 12:20; Matt. 26:28, <strong>r.</strong> Mark 9:24, <strong>s.</strong> Acts 2:37; Acts 16:30, <strong>t.</strong> Rom. 4:11; 1 Cor. 11:28</p></div>
+<p><strong>m.</strong> Isa. 50:10; 1 John 5:13; Ps. 77:1-4, 7-10; Jonah 2:4, <strong>n.</strong> Isa. 54:7-10; Matt. 5:3-4; Ps. 31:22; Ps. 73:13, 22-23, <strong>o.</strong> Phil. 3:8-9; Ps. 10:17; Ps. 42:1-2, 5, 11, <strong>p.</strong> 2 Tim. 2:19; Isa. 50:10; Ps. 66:18-20, <strong>q.</strong> Isa. 40:11, 29, 31; Matt. 11:28; Matt. 12:20; Matt. 26:28, <strong>r.</strong> Mark 9:24, <strong>s.</strong> Acts 2:37; Acts 16:30, <strong>t.</strong> Rom. 4:11; 1 Cor. 11:28</p></div>
 </details>
 
 
@@ -1978,7 +1978,7 @@ Answer: It is required of <span class="v-const">them that</span><span class="v-m
 <details class="scripture-proofs" id="wlc-q174-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Luke 22:19, <strong>b.</strong> 1 Cor. 11:26; 1 Cor. 10:3–5, 11, 14, <strong>c.</strong> 1 Cor. 11:31, <strong>d.</strong> Zech. 12:10, <strong>e.</strong> Rev. 22:17; Matt. 5:6, <strong>f.</strong> John 6:35, <strong>g.</strong> John 1:16, <strong>h.</strong> Phil. 3:9, <strong>u.</strong> 1 Cor. 11:27–34; Matt. 7:6; 1 Tim. 5:22, <strong>w.</strong> 2 Cor. 2:7, <strong>x.</strong> Lev. 10:3, <strong>y.</strong> Matt. 26:28, <strong>z.</strong> 1 Cor. 11:29</p></div>
+<p><strong>a.</strong> Luke 22:19, <strong>b.</strong> 1 Cor. 11:26; 1 Cor. 10:3-5, 11, 14, <strong>c.</strong> 1 Cor. 11:31, <strong>d.</strong> Zech. 12:10, <strong>e.</strong> Rev. 22:17; Matt. 5:6, <strong>f.</strong> John 6:35, <strong>g.</strong> John 1:16, <strong>h.</strong> Phil. 3:9, <strong>u.</strong> 1 Cor. 11:27-34; Matt. 7:6; 1 Tim. 5:22, <strong>w.</strong> 2 Cor. 2:7, <strong>x.</strong> Lev. 10:3, <strong>y.</strong> Matt. 26:28, <strong>z.</strong> 1 Cor. 11:29</p></div>
 </details>
 
 
@@ -1989,7 +1989,7 @@ Answer: The duty of Christians, after they have received the sacrament of the Lo
 <details class="scripture-proofs" id="wlc-q175-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>i.</strong> Ps. 63:4–5; 2 Chron. 30:21; Ps. 22:26; 1 Cor. 10:16, <strong>l.</strong> Jer. 50:5; Ps. 50:5, <strong>m.</strong> Acts 2:42, <strong>n.</strong> Ps. 28:7; Ps. 85:8; 1 Cor. 11:17, 30–31, <strong>o.</strong> 2 Chron. 30:21–23, 25–26; Acts 2:42, 46–47, <strong>p.</strong> Ps. 36:10; Song 3:4; 1 Chron. 29:18, <strong>q.</strong> 1 Cor. 10:3–5, 12, <strong>r.</strong> Ps. 50:14, <strong>s.</strong> 1 Cor. 11:25–26; Acts 2:42, 46, <strong>t.</strong> Ps. 139:23–24, <strong>u.</strong> Ps. 123:1–2; Ps. 42:5, 8</p></div>
+<p><strong>i.</strong> Ps. 63:4-5; 2 Chron. 30:21; Ps. 22:26; 1 Cor. 10:16, <strong>l.</strong> Jer. 50:5; Ps. 50:5, <strong>m.</strong> Acts 2:42, <strong>n.</strong> Ps. 28:7; Ps. 85:8; 1 Cor. 11:17, 30-31, <strong>o.</strong> 2 Chron. 30:21-23, 25-26; Acts 2:42, 46-47, <strong>p.</strong> Ps. 36:10; Song 3:4; 1 Chron. 29:18, <strong>q.</strong> 1 Cor. 10:3-5, 12, <strong>r.</strong> Ps. 50:14, <strong>s.</strong> 1 Cor. 11:25-26; Acts 2:42, 46, <strong>t.</strong> Ps. 139:23-24, <strong>u.</strong> Ps. 123:1-2; Ps. 42:5, 8</p></div>
 </details>
 
 
@@ -2000,7 +2000,7 @@ Answer: The sacraments of baptism and the Lord's supper agree, in that the autho
 <details class="scripture-proofs" id="wlc-q176-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Rom. 4:11; Col. 2:12; Matt. 26:27–28, <strong>w.</strong> 2 Chron. 30:18–19, <strong>x.</strong> 2 Cor. 7:11; 1 Chron. 15:12–14, <strong>y.</strong> Matt. 28:19; 1 Cor. 11:23, <strong>z.</strong> Rom. 6:3–4; 1 Cor. 10:16</p></div>
+<p><strong>a.</strong> Rom. 4:11; Col. 2:12; Matt. 26:27-28, <strong>w.</strong> 2 Chron. 30:18-19, <strong>x.</strong> 2 Cor. 7:11; 1 Chron. 15:12-14, <strong>y.</strong> Matt. 28:19; 1 Cor. 11:23, <strong>z.</strong> Rom. 6:3-4; 1 Cor. 10:16</p></div>
 </details>
 
 
@@ -2011,7 +2011,7 @@ Answer: The sacraments of baptism and the Lord's <span class="v-const"><span cla
 <details class="scripture-proofs" id="wlc-q177-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>b.</strong> John 1:33; Matt. 28:19; 1 Cor. 11:23; 1 Cor. 4:1; Heb. 5:4, <strong>c.</strong> Matt. 28:19–20; 1 Cor. 11:26, <strong>d.</strong> Matt. 3:11; Gal. 3:27, <strong>e.</strong> Gen. 17:7, 9; Acts 2:38–39; 1 Cor. 7:14, <strong>f.</strong> 1 Cor. 11:23–26</p></div>
+<p><strong>b.</strong> John 1:33; Matt. 28:19; 1 Cor. 11:23; 1 Cor. 4:1; Heb. 5:4, <strong>c.</strong> Matt. 28:19-20; 1 Cor. 11:26, <strong>d.</strong> Matt. 3:11; Gal. 3:27, <strong>e.</strong> Gen. 17:7, 9; Acts 2:38-39; 1 Cor. 7:14, <strong>f.</strong> 1 Cor. 11:23-26</p></div>
 </details>
 
 
@@ -2034,7 +2034,7 @@ Answer: God only being able to search the hearts,<sup class="proof-marker">o</su
 <details class="scripture-proofs" id="wlc-q179-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>g.</strong> 1 Cor. 10:16, <strong>h.</strong> 1 Cor. 11:28–29, <strong>i.</strong> Ps. 10:17; Ps. 62:8; Matt. 7:7–8; John 16:23, <strong>l.</strong> Rom. 8:26, <strong>m.</strong> Ps. 32:5–6; 1 John 1:9; Dan. 9:4–19, <strong>n.</strong> Phil. 4:6; Ps. 103:1–5, <strong>o.</strong> 1 Kings 8:39</p></div>
+<p><strong>g.</strong> 1 Cor. 10:16, <strong>h.</strong> 1 Cor. 11:28-29, <strong>i.</strong> Ps. 10:17; Ps. 62:8; Matt. 7:7-8; John 16:23, <strong>l.</strong> Rom. 8:26, <strong>m.</strong> Ps. 32:5-6; 1 John 1:9; Dan. 9:4-19, <strong>n.</strong> Phil. 4:6; Ps. 103:1-5, <strong>o.</strong> 1 Kings 8:39</p></div>
 </details>
 
 
@@ -2045,7 +2045,7 @@ Answer: To pray in the name of Christ is, in obedience to his command, and in co
 <details class="scripture-proofs" id="wlc-q180-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Heb. 4:14–16, <strong>p.</strong> Ps. 65:2, <strong>q.</strong> Mic. 7:18, <strong>r.</strong> Ps. 145:18, <strong>s.</strong> Rom. 10:14, <strong>t.</strong> Matt. 4:10, <strong>u.</strong> 1 Cor. 1:2, <strong>w.</strong> Isa. 45:22; Matt. 6:9; Ps. 50:15, <strong>x.</strong> Isa. 43:11; Isa. 46:9, <strong>y.</strong> John 14:13–14; John 16:24; Dan. 9:17, <strong>z.</strong> Matt. 7:21</p></div>
+<p><strong>a.</strong> Heb. 4:14-16, <strong>p.</strong> Ps. 65:2, <strong>q.</strong> Mic. 7:18, <strong>r.</strong> Ps. 145:18, <strong>s.</strong> Rom. 10:14, <strong>t.</strong> Matt. 4:10, <strong>u.</strong> 1 Cor. 1:2, <strong>w.</strong> Isa. 45:22; Matt. 6:9; Ps. 50:15, <strong>x.</strong> Isa. 43:11; Isa. 46:9, <strong>y.</strong> John 14:13-14; John 16:24; Dan. 9:17, <strong>z.</strong> Matt. 7:21</p></div>
 </details>
 
 
@@ -2068,7 +2068,7 @@ Answer: We not knowing what to pray for as we ought, the Spirit <span class="v-c
 <details class="scripture-proofs" id="wlc-q182-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>b.</strong> John 14:6; Isa. 59:2; Eph. 3:12, <strong>c.</strong> John 6:27; Heb. 7:25–27; 1 Tim. 2:5, <strong>d.</strong> Col. 3:17; Heb. 13:15, <strong>e.</strong> Rom. 8:26–27</p></div>
+<p><strong>b.</strong> John 14:6; Isa. 59:2; Eph. 3:12, <strong>c.</strong> John 6:27; Heb. 7:25-27; 1 Tim. 2:5, <strong>d.</strong> Col. 3:17; Heb. 13:15, <strong>e.</strong> Rom. 8:26-27</p></div>
 </details>
 
 
@@ -2079,7 +2079,7 @@ Answer: We are to pray for the whole church of Christ upon earth;<sup class="pro
 <details class="scripture-proofs" id="wlc-q183-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>f.</strong> Eph. 6:18; Ps. 28:9, <strong>g.</strong> 1 Tim. 2:1–2, <strong>h.</strong> Col. 4:3, <strong>i.</strong> Gen. 32:11, <strong>l.</strong> Matt. 5:44, <strong>m.</strong> 1 Tim. 2:1–2, <strong>n.</strong> John 17:20; 2 Sam. 7:29, <strong>o.</strong> 2 Sam. 12:21–23, <strong>p.</strong> 1 John 5:16</p></div>
+<p><strong>f.</strong> Eph. 6:18; Ps. 28:9, <strong>g.</strong> 1 Tim. 2:1-2, <strong>h.</strong> Col. 4:3, <strong>i.</strong> Gen. 32:11, <strong>l.</strong> Matt. 5:44, <strong>m.</strong> 1 Tim. 2:1-2, <strong>n.</strong> John 17:20; 2 Sam. 7:29, <strong>o.</strong> 2 Sam. 12:21-23, <strong>p.</strong> 1 John 5:16</p></div>
 </details>
 
 
@@ -2102,7 +2102,7 @@ Answer: We are to pray with an <span class="v-const">awful</span><span class="v-
 <details class="scripture-proofs" id="wlc-q185-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Ps. 51:17, <strong>b.</strong> Phil. 4:6, <strong>q.</strong> Matt. 6:9, <strong>r.</strong> Ps. 51:18; Ps. 122:6, <strong>s.</strong> Matt. 7:11, <strong>t.</strong> Ps. 125:4, <strong>u.</strong> 1 John 5:14, <strong>w.</strong> Ps. 33:8; Ps. 95:6; Ps. 145:5, <strong>x.</strong> Gen. 18:27; Gen. 32:10, <strong>y.</strong> Luke 15:17–19, <strong>z.</strong> Luke 18:13–14</p></div>
+<p><strong>a.</strong> Ps. 51:17, <strong>b.</strong> Phil. 4:6, <strong>q.</strong> Matt. 6:9, <strong>r.</strong> Ps. 51:18; Ps. 122:6, <strong>s.</strong> Matt. 7:11, <strong>t.</strong> Ps. 125:4, <strong>u.</strong> 1 John 5:14, <strong>w.</strong> Ps. 33:8; Ps. 95:6; Ps. 145:5, <strong>x.</strong> Gen. 18:27; Gen. 32:10, <strong>y.</strong> Luke 15:17-19, <strong>z.</strong> Luke 18:13-14</p></div>
 </details>
 
 
@@ -2113,7 +2113,7 @@ Answer: The whole Word of God is of use to direct us in the duty of prayer;<sup 
 <details class="scripture-proofs" id="wlc-q186-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>c.</strong> 1 Sam. 1:15; 1 Sam. 2:1, <strong>d.</strong> 1 Cor. 14:15, <strong>e.</strong> Mark 11:24, <strong>f.</strong> Ps. 145:18; Ps. 17:1, <strong>h.</strong> Ps. 116:1–2; Rom. 15:30, <strong>i.</strong> Eph. 6:18; Mic. 7:7, <strong>l.</strong> Matt. 26:39, <strong>m.</strong> 1 John 5:14, <strong>n.</strong> Matt. 6:9–13; Luke 11:2–4</p></div>
+<p><strong>c.</strong> 1 Sam. 1:15; 1 Sam. 2:1, <strong>d.</strong> 1 Cor. 14:15, <strong>e.</strong> Mark 11:24, <strong>f.</strong> Ps. 145:18; Ps. 17:1, <strong>h.</strong> Ps. 116:1-2; Rom. 15:30, <strong>i.</strong> Eph. 6:18; Mic. 7:7, <strong>l.</strong> Matt. 26:39, <strong>m.</strong> 1 John 5:14, <strong>n.</strong> Matt. 6:9-13; Luke 11:2-4</p></div>
 </details>
 
 
@@ -2140,7 +2140,7 @@ Answer: The preface of the Lord's <span cl<span class="v-const">as</span><span c
 <details class="scripture-proofs" id="wlc-q189-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>o.</strong> Matt. 6:9; Luke 11:2, <strong>p.</strong> Matt. 6:9; Luke 11:2, <strong>q.</strong> Ps. 103:13; Luke 11:13; Rom. 8:15, <strong>r.</strong> Isa. 64:9, <strong>s.</strong> Col. 3:1–2; Ps. 123:1; Lam. 3:41, <strong>t.</strong> Isa. 63:15–16; Neh. 1:4–6</p></div>
+<p><strong>o.</strong> Matt. 6:9; Luke 11:2, <strong>p.</strong> Matt. 6:9; Luke 11:2, <strong>q.</strong> Ps. 103:13; Luke 11:13; Rom. 8:15, <strong>r.</strong> Isa. 64:9, <strong>s.</strong> Col. 3:1-2; Ps. 123:1; Lam. 3:41, <strong>t.</strong> Isa. 63:15-16; Neh. 1:4-6</p></div>
 </details>
 
 
@@ -2151,7 +2151,7 @@ Answer: In the first <span class="v-const">petition</span><span class="v-modern"
 <details class="scripture-proofs" id="wlc-q190-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Ps. 86:10–13, 15, <strong>b.</strong> 2 Thess. 3:1; Ps. 147:19–20; Ps. 138:1–3; 2 Cor. 2:14–15, <strong>d.</strong> Ps. 103:1; Ps. 19:14, <strong>e.</strong> Phil. 1:9, 11; Ps. 100:3–4, <strong>f.</strong> Ps. 67:1–4, <strong>g.</strong> Eph. 1:17–18, <strong>h.</strong> Ps. 97:7, <strong>i.</strong> Ps. 74:18, 22–23; 2 Kings 19:15–16, <strong>l.</strong> 2 Chron. 20:6; Rom. 11:33–36, <strong>u.</strong> Acts 12:5; 1 Tim. 2:1–2; Eph. 6:18, <strong>w.</strong> Matt. 6:9; Luke 11:2, <strong>x.</strong> 2 Cor. 3:5; Ps. 51:15, <strong>y.</strong> Ps. 67:2–3; Ps. 99:1–3, <strong>z.</strong> Ps. 83:18</p></div>
+<p><strong>a.</strong> Ps. 86:10-13, 15, <strong>b.</strong> 2 Thess. 3:1; Ps. 147:19-20; Ps. 138:1-3; 2 Cor. 2:14-15, <strong>d.</strong> Ps. 103:1; Ps. 19:14, <strong>e.</strong> Phil. 1:9, 11; Ps. 100:3-4, <strong>f.</strong> Ps. 67:1-4, <strong>g.</strong> Eph. 1:17-18, <strong>h.</strong> Ps. 97:7, <strong>i.</strong> Ps. 74:18, 22-23; 2 Kings 19:15-16, <strong>l.</strong> 2 Chron. 20:6; Rom. 11:33-36, <strong>u.</strong> Acts 12:5; 1 Tim. 2:1-2; Eph. 6:18, <strong>w.</strong> Matt. 6:9; Luke 11:2, <strong>x.</strong> 2 Cor. 3:5; Ps. 51:15, <strong>y.</strong> Ps. 67:2-3; Ps. 99:1-3, <strong>z.</strong> Ps. 83:18</p></div>
 </details>
 
 
@@ -2162,7 +2162,7 @@ Answer: In the second <span class="v-const">petition</span><span class="v-modern
 <details class="scripture-proofs" id="wlc-q191-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>m.</strong> Matt. 6:10; Luke 11:2, <strong>n.</strong> Eph. 2:2–3, <strong>o.</strong> Ps. 68:1, 18; Rev. 12:10–11, <strong>p.</strong> Ps. 67:1–2; 2 Thess. 3:1, <strong>q.</strong> Rom. 10:1, <strong>r.</strong> John 17:9, 20; Rom. 11:25–26, <strong>s.</strong> Matt. 9:38; 2 Thess. 3:1, <strong>t.</strong> Mal. 1:11, <strong>u.</strong> 1 Tim. 2:1–2; Isa. 49:23, <strong>w.</strong> Acts 4:29–30; Eph. 6:18–20; Rom. 15:29–30, 32; 2 Thess. 1:11; 2 Thess. 2:16–17, <strong>x.</strong> Eph. 3:14–20; Col. 3:15, <strong>y.</strong> Rev. 22:20; 2 Tim. 2:12; 2 Pet. 3:12</p></div>
+<p><strong>m.</strong> Matt. 6:10; Luke 11:2, <strong>n.</strong> Eph. 2:2-3, <strong>o.</strong> Ps. 68:1, 18; Rev. 12:10-11, <strong>p.</strong> Ps. 67:1-2; 2 Thess. 3:1, <strong>q.</strong> Rom. 10:1, <strong>r.</strong> John 17:9, 20; Rom. 11:25-26, <strong>s.</strong> Matt. 9:38; 2 Thess. 3:1, <strong>t.</strong> Mal. 1:11, <strong>u.</strong> 1 Tim. 2:1-2; Isa. 49:23, <strong>w.</strong> Acts 4:29-30; Eph. 6:18-20; Rom. 15:29-30, 32; 2 Thess. 1:11; 2 Thess. 2:16-17, <strong>x.</strong> Eph. 3:14-20; Col. 3:15, <strong>y.</strong> Rev. 22:20; 2 Tim. 2:12; 2 Pet. 3:12</p></div>
 </details>
 
 
@@ -2173,7 +2173,7 @@ Answer: In the third <span class="v-const">petition</span><span class="v-modern"
 <details class="scripture-proofs" id="wlc-q192-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Matt. 6:10; Luke 11:2, <strong>b.</strong> Rom. 7:18; Job 21:14; 1 Cor. 2:14, <strong>c.</strong> Rom. 8:7, <strong>d.</strong> Num. 14:2, <strong>e.</strong> Eph. 2:2, <strong>f.</strong> Eph. 1:17–18, <strong>g.</strong> Eph. 3:16, <strong>h.</strong> Matt. 26:40–41, <strong>i.</strong> Jer. 31:18–19; Ps. 19:14; Acts 21:14; 1 Thess. 5:23; Heb. 13:20–21, <strong>l.</strong> Mic. 6:8, <strong>m.</strong> Ps. 100:2; Job 1:21; 2 Sam. 15:25–26, <strong>n.</strong> Isa. 38:3, <strong>o.</strong> Ps. 119:4–5, <strong>p.</strong> Ps. 69:9; John 2:17; Rom. 12:11, <strong>q.</strong> Josh. 24:14; Ps. 119:80; 1 Cor. 5:8; 2 Cor. 1:12, <strong>r.</strong> Ps. 119:112, <strong>s.</strong> Isa. 6:2–3, <strong>z.</strong> Isa. 64:1–2; Rev. 4:8–11</p></div>
+<p><strong>a.</strong> Matt. 6:10; Luke 11:2, <strong>b.</strong> Rom. 7:18; Job 21:14; 1 Cor. 2:14, <strong>c.</strong> Rom. 8:7, <strong>d.</strong> Num. 14:2, <strong>e.</strong> Eph. 2:2, <strong>f.</strong> Eph. 1:17-18, <strong>g.</strong> Eph. 3:16, <strong>h.</strong> Matt. 26:40-41, <strong>i.</strong> Jer. 31:18-19; Ps. 19:14; Acts 21:14; 1 Thess. 5:23; Heb. 13:20-21, <strong>l.</strong> Mic. 6:8, <strong>m.</strong> Ps. 100:2; Job 1:21; 2 Sam. 15:25-26, <strong>n.</strong> Isa. 38:3, <strong>o.</strong> Ps. 119:4-5, <strong>p.</strong> Ps. 69:9; John 2:17; Rom. 12:11, <strong>q.</strong> Josh. 24:14; Ps. 119:80; 1 Cor. 5:8; 2 Cor. 1:12, <strong>r.</strong> Ps. 119:112, <strong>s.</strong> Isa. 6:2-3, <strong>z.</strong> Isa. 64:1-2; Rev. 4:8-11</p></div>
 </details>
 
 
@@ -2184,7 +2184,7 @@ Answer: In the fourth <span class="v-const">petition</span><span class="v-modern
 <details class="scripture-proofs" id="wlc-q193-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>t.</strong> Matt. 6:11; Luke 11:3, <strong>u.</strong> Gen. 2:17; Gen. 3:17; Rom. 8:20–22; Jer. 5:25; Deut. 28:15–68, <strong>w.</strong> Deut. 8:3, <strong>x.</strong> Gen. 32:10, <strong>y.</strong> Deut. 8:17–18, <strong>z.</strong> Jer. 6:13; Mark 7:21–22</p></div>
+<p><strong>t.</strong> Matt. 6:11; Luke 11:3, <strong>u.</strong> Gen. 2:17; Gen. 3:17; Rom. 8:20-22; Jer. 5:25; Deut. 28:15-68, <strong>w.</strong> Deut. 8:3, <strong>x.</strong> Gen. 32:10, <strong>y.</strong> Deut. 8:17-18, <strong>z.</strong> Jer. 6:13; Mark 7:21-22</p></div>
 </details>
 
 
@@ -2195,7 +2195,7 @@ Answer: In the fifth <span class="v-const">petition</span><span class="v-modern"
 <details class="scripture-proofs" id="wlc-q194-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Hos. 12:7, <strong>c.</strong> Gen. 43:12–14; Gen. 28:20; Eph. 4:28; 2 Thess. 3:11–12; Phil. 4:6, <strong>d.</strong> 1 Tim. 4:3–5, <strong>e.</strong> 1 Tim. 6:6–8, <strong>f.</strong> Prov. 30:8–9, <strong>g.</strong> Matt. 6:12; Luke 11:4, <strong>h.</strong> Rom. 3:9–22; Matt. 18:24–25; Ps. 130:3–4, <strong>i.</strong> Rom. 3:24–26; Heb. 9:22; Eph. 1:6–7, <strong>l.</strong> 2 Pet. 1:2, <strong>m.</strong> Hos. 14:2; Jer. 14:7; 1 John 1:9; Dan. 9:17–19, <strong>n.</strong> Rom. 15:13; Ps. 51:7–10, 12</p></div>
+<p><strong>a.</strong> Hos. 12:7, <strong>c.</strong> Gen. 43:12-14; Gen. 28:20; Eph. 4:28; 2 Thess. 3:11-12; Phil. 4:6, <strong>d.</strong> 1 Tim. 4:3-5, <strong>e.</strong> 1 Tim. 6:6-8, <strong>f.</strong> Prov. 30:8-9, <strong>g.</strong> Matt. 6:12; Luke 11:4, <strong>h.</strong> Rom. 3:9-22; Matt. 18:24-25; Ps. 130:3-4, <strong>i.</strong> Rom. 3:24-26; Heb. 9:22; Eph. 1:6-7, <strong>l.</strong> 2 Pet. 1:2, <strong>m.</strong> Hos. 14:2; Jer. 14:7; 1 John 1:9; Dan. 9:17-19, <strong>n.</strong> Rom. 15:13; Ps. 51:7-10, 12</p></div>
 </details>
 
 
@@ -2206,7 +2206,7 @@ Answer: In the sixth <span class="v-const">petition</span><span class="v-modern"
 <details class="scripture-proofs" id="wlc-q195-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> John 17:15, <strong>b.</strong> Ps. 51:10; Ps. 119:133, <strong>c.</strong> 2 Cor. 12:7–8, <strong>d.</strong> 1 Cor. 10:12–13, <strong>e.</strong> Heb. 13:20–21, <strong>f.</strong> Matt. 26:41; Ps. 19:13, <strong>g.</strong> Eph. 3:14–17; 1 Thess. 3:13, <strong>h.</strong> Ps. 51:12, <strong>i.</strong> 1 Pet. 5:8–10; 2 Cor. 13:7, 9, <strong>o.</strong> Luke 11:4; Matt. 6:14–15; Eph. 4:32; Col. 3:13; Matt. 18:21–35, <strong>p.</strong> Matt. 6:13; Luke 11:4, <strong>q.</strong> 2 Chron. 32:31, <strong>r.</strong> 1 Chron. 21:1, <strong>s.</strong> Luke 21:34; Mark 4:19, <strong>u.</strong> Gal. 5:17, <strong>w.</strong> Matt. 26:41, <strong>x.</strong> Matt. 26:69–72, <strong>y.</strong> Rom. 7:23–24; 1 Chron. 21:1–4; 2 Chron. 16:7–10, <strong>z.</strong> Ps. 81:11–12</p></div>
+<p><strong>a.</strong> John 17:15, <strong>b.</strong> Ps. 51:10; Ps. 119:133, <strong>c.</strong> 2 Cor. 12:7-8, <strong>d.</strong> 1 Cor. 10:12-13, <strong>e.</strong> Heb. 13:20-21, <strong>f.</strong> Matt. 26:41; Ps. 19:13, <strong>g.</strong> Eph. 3:14-17; 1 Thess. 3:13, <strong>h.</strong> Ps. 51:12, <strong>i.</strong> 1 Pet. 5:8-10; 2 Cor. 13:7, 9, <strong>o.</strong> Luke 11:4; Matt. 6:14-15; Eph. 4:32; Col. 3:13; Matt. 18:21-35, <strong>p.</strong> Matt. 6:13; Luke 11:4, <strong>q.</strong> 2 Chron. 32:31, <strong>r.</strong> 1 Chron. 21:1, <strong>s.</strong> Luke 21:34; Mark 4:19, <strong>u.</strong> Gal. 5:17, <strong>w.</strong> Matt. 26:41, <strong>x.</strong> Matt. 26:69-72, <strong>y.</strong> Rom. 7:23-24; 1 Chron. 21:1-4; 2 Chron. 16:7-10, <strong>z.</strong> Ps. 81:11-12</p></div>
 </details>
 
 
@@ -2217,7 +2217,7 @@ Answer: The conclusion of the Lord's <span class="v-const">prayer</span><span cl
 <details class="scripture-proofs" id="wlc-q196-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Rom. 16:20; Luke 22:31–32, <strong>m.</strong> John 17:15; 1 Thess. 5:23, <strong>n.</strong> Matt. 6:13, <strong>o.</strong> Rom. 15:30, <strong>p.</strong> Dan. 9:4, 7–9, 16–19, <strong>q.</strong> Phil. 4:6, <strong>r.</strong> 1 Chron. 29:10–13, <strong>s.</strong> Eph. 3:20–21; Luke 11:13, <strong>t.</strong> 2 Chron. 20:6, 11, <strong>u.</strong> 2 Chron. 14:11, <strong>w.</strong> 1 Cor. 14:16; Rev. 22:20–21</p></div>
+<p><strong>l.</strong> Rom. 16:20; Luke 22:31-32, <strong>m.</strong> John 17:15; 1 Thess. 5:23, <strong>n.</strong> Matt. 6:13, <strong>o.</strong> Rom. 15:30, <strong>p.</strong> Dan. 9:4, 7-9, 16-19, <strong>q.</strong> Phil. 4:6, <strong>r.</strong> 1 Chron. 29:10-13, <strong>s.</strong> Eph. 3:20-21; Luke 11:13, <strong>t.</strong> 2 Chron. 20:6, 11, <strong>u.</strong> 2 Chron. 14:11, <strong>w.</strong> 1 Cor. 14:16; Rev. 22:20-21</p></div>
 </details>
 
 

--- a/_pages/wlc.md
+++ b/_pages/wlc.md
@@ -18,7 +18,7 @@ Answer: Man's chief and highest end is to glorify God,<sup class="proof-marker">
 
 
 <span id="wlc-q2"></span>
-### Question 2: How <span class="v-const">doth</span><span class="v-modern">does</span> it appear that there is a God?
+### Question 2: How doth it appear that there is a God?
 Answer: The very light of nature in man, and the works of God, declare plainly that there is a God;<sup class="proof-marker">c</sup> but his <span class="v-const">word</span><span class="v-modern">Word</span> and Spirit <span class="v-const">only do</span><span class="v-modern">alone</span> sufficiently and effectually reveal him <span class="v-const">unto</span><span class="v-modern">to</span> men for their salvation.<sup class="proof-marker">d</sup>
 
 <details class="scripture-proofs" id="wlc-q2-proofs">
@@ -41,7 +41,7 @@ Answer: The Holy Scriptures of the Old and New Testament are the Word of God,<su
 
 
 <span id="wlc-q4"></span>
-### Question 4: How <span class="v-const">doth</span><span class="v-modern">does</span> it appear that the Scriptures are the Word of God?
+### Question 4: How doth it appear that the Scriptures are the Word of God?
 Answer: The Scriptures manifest themselves to be the Word of God, by their majesty and purity;<sup class="proof-marker">h</sup> by the consent of all the parts,<sup class="proof-marker">i</sup> and the scope of the whole, which is to give all glory to God; by their light and power to convince and convert sinners, to comfort and build up believers <span class="v-const">unto</span><span class="v-modern">to</span> salvation:<sup class="proof-marker">l</sup> but <span class="v-modern">only</span> the Spirit of God bearing witness by and with the Scriptures in the heart of <span class="v-const">man,</span><span class="v-modern">man</span> is <span class="v-const">alone</span> able fully to persuade it that they are the very Word of God.<sup class="proof-marker">m</sup>
 
 <details class="scripture-proofs" id="wlc-q4-proofs">
@@ -122,7 +122,7 @@ Answer: It is proper to the Father to beget the <span class="v-const">Son,</span
 
 
 <span id="wlc-q11"></span>
-### Question 11: How <span class="v-const">doth</span><span class="v-modern">does</span> it appear that the Son and the Holy <span class="v-const">Ghost</span><span class="v-modern">Spirit</span> are God equal with the Father?
+### Question 11: How doth it appear that the Son and the Holy Ghost are God equal with the Father?
 Answer: The Scriptures manifest that the Son and the Holy <span class="v-const">Ghost</span><span class="v-modern">Spirit</span> are God equal with the Father, ascribing <span class="v-const">unto</span><span class="v-modern">to</span> them such names,<sup class="proof-marker">s</sup> attributes,<sup class="proof-marker">t</sup> works,<sup class="proof-marker">u</sup> and worship,<sup class="proof-marker">w</sup> as are proper to God only.
 
 <details class="scripture-proofs" id="wlc-q11-proofs">
@@ -144,7 +144,7 @@ Answer: God's decrees are the wise, free, and holy acts of the counsel of his wi
 
 
 <span id="wlc-q13"></span>
-### Question 13: What <span class="v-const">hath</span><span class="v-modern">has</span> God especially decreed concerning angels and men?
+### Question 13: What hath God especially decreed concerning angels and men?
 Answer: God, by an eternal and immutable decree, out of his mere love, for the praise of his glorious grace, to be manifested in due time, <span class="v-const">hath</span><span class="v-modern">has</span> elected some angels to glory;<sup class="proof-marker">z</sup> and in Christ <span class="v-const">hath</span><span class="v-modern">has</span> chosen some men to eternal life, and the means <span class="v-const">thereof:</span><span class="v-modern">to this end:</span><sup class="proof-marker">a</sup> and also, according to his sovereign power, and the unsearchable counsel of his own <span class="v-const">will (whereby</span><span class="v-modern">will, (by which</span> he <span class="v-const">extendeth</span><span class="v-modern">extends</span> or <span class="v-const">withholdeth</span><span class="v-modern">withholds</span> favor as he <span class="v-const">pleaseth), hath</span><span class="v-modern">pleases,) has</span> passed by and foreordained the rest to dishonor and wrath, to be <span class="v-modern">inflicted</span> for their <span class="v-const">sin inflicted,</span><span class="v-modern">sin,</span> to the praise of the glory of his justice.<sup class="proof-marker">b</sup>
 
 <details class="scripture-proofs" id="wlc-q13-proofs">
@@ -156,7 +156,7 @@ Answer: God, by an eternal and immutable decree, out of his mere love, for the p
 
 
 <span id="wlc-q14"></span>
-### Question 14: How <span class="v-const">doth</span><span class="v-modern">does</span> God execute his decrees?
+### Question 14: How doth God execute his decrees?
 Answer: God <span class="v-const">executeth</span><span class="v-modern">executes</span> his decrees in the works of creation and providence,<sup class="proof-marker">c</sup> according to his infallible foreknowledge, and the free and immutable counsel of his own will.<sup class="proof-marker">d</sup>
 
 <details class="scripture-proofs" id="wlc-q14-proofs">
@@ -224,7 +224,7 @@ Answer: God by his providence permitted some of the angels, willfully and irreco
 
 
 <span id="wlc-q20"></span>
-### Question 20: What was the providence of God toward man in the <span class="v-const">estate</span><span class="v-modern">state</span> in which he was created?
+### Question 20: What was the providence of God toward man in the estate in which he was created?
 Answer: The providence of God toward man in the <span class="v-const">estate</span><span class="v-modern">state</span> in which he was created, was <span class="v-const">the</span> placing him in paradise, appointing him to <span class="v-const">dress</span><span class="v-modern">work</span> it, giving him liberty to eat of the fruit of the earth;<sup class="proof-marker">m</sup> putting the creatures under his dominion,<sup class="proof-marker">n</sup> and ordaining marriage for his help;<sup class="proof-marker">o</sup> affording him communion with himself;<sup class="proof-marker">p</sup> instituting the Sabbath;<sup class="proof-marker">q</sup> entering into a covenant of life with him, upon condition of personal, perfect, and perpetual obedience,<sup class="proof-marker">r</sup> of which the tree of life was a pledge;<sup class="proof-marker">s</sup> and forbidding to eat of the tree of the knowledge of good and evil, upon the pain of death.<sup class="proof-marker">t</sup>
 
 <details class="scripture-proofs" id="wlc-q20-proofs">
@@ -235,7 +235,7 @@ Answer: The providence of God toward man in the <span class="v-const">estate</sp
 
 
 <span id="wlc-q21"></span>
-### Question 21: Did man continue in that <span class="v-const">estate wherein</span><span class="v-modern">state in which</span> God at first created him?
+### Question 21: Did man continue in that estate wherein God at first created him?
 Answer: Our first parents being left to the freedom of their own will, through the temptation of Satan, transgressed the commandment of God in eating the forbidden fruit; and <span class="v-const">thereby</span><span class="v-modern">by this</span> fell from the <span class="v-const">estate</span><span class="v-modern">state</span> of <span class="v-const">innocency wherein</span><span class="v-modern">innocence in which</span> they were created.<sup class="proof-marker">u</sup>
 
 <details class="scripture-proofs" id="wlc-q21-proofs">
@@ -258,7 +258,7 @@ Answer: The covenant being made with Adam as a public person, not for himself on
 
 
 <span id="wlc-q23"></span>
-### Question 23: Into what <span class="v-const">estate</span><span class="v-modern">state</span> did the fall bring mankind?
+### Question 23: Into what estate did the fall bring mankind?
 Answer: The fall brought mankind into <span class="v-const">an estate</span><span class="v-modern">a state</span> of sin and misery.<sup class="proof-marker">y</sup>
 
 <details class="scripture-proofs" id="wlc-q23-proofs">
@@ -282,7 +282,7 @@ Answer: Sin is any <span class="v-const">want</span><span class="v-modern">lack<
 
 
 <span id="wlc-q25"></span>
-### Question 25: <span class="v-const">Wherein consisteth</span><span class="v-modern">What is</span> the sinfulness of that <span class="v-const">estate whereinto</span><span class="v-modern">state into which</span> man fell?
+### Question 25: Wherein consisteth the sinfulness of that estate whereinto man fell?
 Answer: The sinfulness of that <span class="v-const">estate whereinto</span><span class="v-modern">state into which</span> man fell, <span class="v-const">consisteth</span><span class="v-modern">consists</span> in the guilt of Adam's first sin,<sup class="proof-marker">a</sup> the <span class="v-const">want</span><span class="v-modern">lack</span> of that righteousness <span class="v-const">wherein</span><span class="v-modern">in which</span> he was created, and the corruption of his nature, <span class="v-const">whereby</span><span class="v-modern">by which</span> he is utterly indisposed, disabled, and made opposite <span class="v-const">unto</span><span class="v-modern">to</span> all that is spiritually good, and wholly inclined to all evil, and that continually;<sup class="proof-marker">b</sup> which is commonly called original sin, and from which <span class="v-const">do</span> proceed all actual transgressions.<sup class="proof-marker">c</sup>
 
 <details class="scripture-proofs" id="wlc-q25-proofs">
@@ -293,7 +293,7 @@ Answer: The sinfulness of that <span class="v-const">estate whereinto</span><spa
 
 
 <span id="wlc-q26"></span>
-### Question 26: How is original sin conveyed from our first parents <span class="v-const">unto</span><span class="v-modern">to</span> their posterity?
+### Question 26: How is original sin conveyed from our first parents unto their posterity?
 Answer: Original sin is conveyed from our first parents <span class="v-const">unto</span><span class="v-modern">to</span> their posterity by natural generation, so <span class="v-const">as</span><span class="v-modern">that</span> all that proceed from them in that way are conceived and born in sin.<sup class="proof-marker">d</sup>
 
 <details class="scripture-proofs" id="wlc-q26-proofs">
@@ -339,7 +339,7 @@ Answer: The punishments of sin in the world to come, are everlasting separation 
 
 
 <span id="wlc-q30"></span>
-### Question 30: <span class="v-const">Doth</span><span class="v-modern">Does</span> God leave all mankind to perish in the <span class="v-const">estate</span><span class="v-modern">state</span> of sin and misery?
+### Question 30: Doth God leave all mankind to perish in the estate of sin and misery?
 Answer: God <span class="v-const">doth</span><span class="v-modern">does</span> not leave all men to perish in the <span class="v-const">estate</span><span class="v-modern">state</span> of sin and misery,<sup class="proof-marker">u</sup> into which they fell by the breach of the first covenant, commonly called the covenant of works;<sup class="proof-marker">w</sup> but of his mere love and mercy <span class="v-const">delivereth</span><span class="v-modern">delivers</span> his elect out of it, and <span class="v-const">bringeth</span><span class="v-modern">brings</span> them into <span class="v-const">an estate</span><span class="v-modern">a state</span> of salvation by the second covenant, commonly called the covenant of grace.<sup class="proof-marker">x</sup>
 
 <details class="scripture-proofs" id="wlc-q30-proofs">
@@ -373,7 +373,7 @@ Answer: The grace of God is manifested in the second covenant, in that he freely
 
 
 <span id="wlc-q33"></span>
-### Question 33: Was the covenant of grace always administered <span class="v-const">after</span><span class="v-modern">in</span> one and the same manner?
+### Question 33: Was the covenant of grace always administered after one and the same manner?
 Answer: The covenant of grace was not always administered <span class="v-const">after</span><span class="v-modern">in</span> the same manner, but the administrations of it under the <span class="v-const">Old Testament</span><span class="v-modern">old testament</span> were different from those under the <span class="v-const">New.</span><span class="v-modern">new.</span>
 
 <details class="scripture-proofs" id="wlc-q33-proofs">
@@ -486,7 +486,7 @@ Answer: Our <span class="v-const">mediator</span><span class="v-modern">Mediator
 
 
 <span id="wlc-q43"></span>
-### Question 43: How <span class="v-const">doth</span><span class="v-modern">does</span> Christ execute the office of a prophet?
+### Question 43: How doth Christ execute the office of a prophet?
 Answer: Christ <span class="v-const">executeth</span><span class="v-modern">executes</span> the office of a prophet, in his revealing to the church,<sup class="proof-marker">c</sup> in all ages, by his Spirit and <span class="v-const">word,</span><span class="v-modern">Word,</span><sup class="proof-marker">d</sup> in <span class="v-const">divers</span><span class="v-modern">various</span> ways of administration,<sup class="proof-marker">e</sup> the whole will of God,<sup class="proof-marker">f</sup> in all things concerning their edification and salvation.<sup class="proof-marker">g</sup>
 
 <details class="scripture-proofs" id="wlc-q43-proofs">
@@ -497,7 +497,7 @@ Answer: Christ <span class="v-const">executeth</span><span class="v-modern">exec
 
 
 <span id="wlc-q44"></span>
-### Question 44: How <span class="v-const">doth</span><span class="v-modern">does</span> Christ execute the office of a priest?
+### Question 44: How doth Christ execute the office of a priest?
 Answer: Christ <span class="v-const">executeth</span><span class="v-modern">executes</span> the office of a priest, in his once offering himself <span class="v-modern">as</span> a sacrifice without spot to God,<sup class="proof-marker">h</sup> to be a reconciliation for the sins of <span class="v-const">the</span><span class="v-modern">his</span> people; and in making continual intercession for them.
 
 <details class="scripture-proofs" id="wlc-q44-proofs">
@@ -508,7 +508,7 @@ Answer: Christ <span class="v-const">executeth</span><span class="v-modern">exec
 
 
 <span id="wlc-q45"></span>
-### Question 45: How <span class="v-const">doth</span><span class="v-modern">does</span> Christ execute the office of a king?
+### Question 45: How doth Christ execute the office of a king?
 Answer: Christ <span class="v-const">executeth</span><span class="v-modern">executes</span> the office of a king, in calling out of the world a people to himself,<sup class="proof-marker">l</sup> and giving them officers,<sup class="proof-marker">m</sup> laws,<sup class="proof-marker">n</sup> and censures, by which he visibly governs them;<sup class="proof-marker">o</sup> in bestowing saving grace upon his elect,<sup class="proof-marker">p</sup> rewarding their obedience,<sup class="proof-marker">q</sup> and correcting them for their sins, preserving and supporting them under all their temptations and sufferings,<sup class="proof-marker">s</sup> restraining and overcoming all their enemies,<sup class="proof-marker">t</sup> and powerfully ordering all things for his own glory,<sup class="proof-marker">u</sup> and their good;<sup class="proof-marker">w</sup> and also in taking vengeance on the rest, who <span class="v-modern">do not</span> know <span class="v-const">not</span> God, and <span class="v-modern">do not</span> obey <span class="v-const">not</span> the gospel.<sup class="proof-marker">x</sup>
 
 <details class="scripture-proofs" id="wlc-q45-proofs">
@@ -519,7 +519,7 @@ Answer: Christ <span class="v-const">executeth</span><span class="v-modern">exec
 
 
 <span id="wlc-q46"></span>
-### Question 46: What was the <span class="v-const">estate</span><span class="v-modern">state</span> of Christ's humiliation?
+### Question 46: What was the estate of Christ's humiliation?
 Answer: The <span class="v-const">estate</span><span class="v-modern">state</span> of Christ's humiliation was that low condition, <span class="v-const">wherein</span><span class="v-modern">in which</span> he for our sakes, emptying himself of his glory, took upon <span class="v-const">him</span><span class="v-modern">himself</span> the form of a servant,<sup class="proof-marker">y</sup> in his conception and birth,<sup class="proof-marker">a</sup> life,<sup class="proof-marker">b</sup> death,<sup class="proof-marker">c</sup> and after his death,<sup class="proof-marker">d</sup> until his resurrection.<sup class="proof-marker">e</sup>
 
 <details class="scripture-proofs" id="wlc-q46-proofs">
@@ -564,7 +564,7 @@ Answer: Christ humbled himself in his death, in that having been betrayed by Jud
 
 
 <span id="wlc-q50"></span>
-### Question 50: <span class="v-const">Wherein consisted</span><span class="v-modern">What was</span> Christ's humiliation after his death?
+### Question 50: Wherein consisted Christ's humiliation after his death?
 Answer: Christ's humiliation after his death consisted in his being buried,<sup class="proof-marker">t</sup> <span class="v-const">and</span> continuing in the state of the dead, and <span class="v-modern">continuing</span> under the power of death till the third day;<sup class="proof-marker">u</sup> which <span class="v-const">hath</span><span class="v-modern">has</span> been otherwise expressed in these words, He descended into hell.
 
 <details class="scripture-proofs" id="wlc-q50-proofs">
@@ -575,7 +575,7 @@ Answer: Christ's humiliation after his death consisted in his being buried,<sup 
 
 
 <span id="wlc-q51"></span>
-### Question 51: What was the <span class="v-const">estate</span><span class="v-modern">state</span> of Christ's exaltation?
+### Question 51: What was the estate of Christ's exaltation?
 Answer: The <span class="v-const">estate</span><span class="v-modern">state</span> of Christ's exaltation <span class="v-const">comprehendeth</span><span class="v-modern">comprehends</span> his resurrection,<sup class="proof-marker">w</sup> ascension,<sup class="proof-marker">x</sup> sitting at the right hand of the Father,<sup class="proof-marker">y</sup> and his coming again to judge the world.<sup class="proof-marker">z</sup>
 
 <details class="scripture-proofs" id="wlc-q51-proofs">
@@ -620,7 +620,7 @@ Answer: Christ is exalted in his sitting at the right hand of God, in that as Go
 
 
 <span id="wlc-q55"></span>
-### Question 55: How <span class="v-const">doth</span><span class="v-modern">does</span> Christ make intercession?
+### Question 55: How doth Christ make intercession?
 Answer: Christ <span class="v-const">maketh</span><span class="v-modern">makes</span> intercession, by his appearing in our nature continually before the Father in heaven,<sup class="proof-marker">e</sup> in the merit of his obedience and sacrifice on earth,<sup class="proof-marker">f</sup> declaring his will to have it applied to all believers;<sup class="proof-marker">g</sup>answering all accusations against them,<sup class="proof-marker">h</sup> and procuring for them quiet of conscience, <span class="v-const">notwithstanding</span><span class="v-modern">in spite of</span> daily failings,<sup class="proof-marker">i</sup> access with boldness to the throne of grace, and acceptance of their persons and services.<sup class="proof-marker">m</sup>
 
 <details class="scripture-proofs" id="wlc-q55-proofs">
@@ -642,7 +642,7 @@ Answer: Christ is to be exalted in his coming again to judge the world, in that 
 
 
 <span id="wlc-q57"></span>
-### Question 57: What benefits <span class="v-const">hath</span><span class="v-modern">has</span> Christ procured by his mediation?
+### Question 57: What benefits hath Christ procured by his mediation?
 Answer: Christ, by his mediation, <span class="v-const">hath</span><span class="v-modern">has</span> procured redemption,<sup class="proof-marker">s</sup> with all other benefits of the covenant of grace.<sup class="proof-marker">t</sup>
 
 <details class="scripture-proofs" id="wlc-q57-proofs">
@@ -654,7 +654,7 @@ Answer: Christ, by his mediation, <span class="v-const">hath</span><span class="
 
 
 <span id="wlc-q58"></span>
-### Question 58: How <span class="v-const">do</span><span class="v-modern">are</span> we <span class="v-const">come to be</span> made partakers of the benefits <span class="v-const">which</span><span class="v-modern">that</span> Christ <span class="v-const">hath</span><span class="v-modern">has</span> procured?
+### Question 58: How do we come to be made partakers of the benefits which Christ hath procured?
 Answer: We are made partakers of the benefits <span class="v-const">which</span><span class="v-modern">that</span> Christ <span class="v-const">hath</span><span class="v-modern">has</span> procured, by the application of them <span class="v-const">unto</span><span class="v-modern">to</span> us,<sup class="proof-marker">u</sup> which is the work especially of God the Holy <span class="v-const">Ghost.</span><span class="v-modern">Spirit.</span><sup class="proof-marker">w</sup>
 
 <details class="scripture-proofs" id="wlc-q58-proofs">
@@ -677,7 +677,7 @@ Answer: Redemption is certainly applied, and effectually communicated, to all th
 
 
 <span id="wlc-q60"></span>
-### Question 60: Can <span class="v-const">they</span><span class="v-modern">those</span> who have never heard the gospel, and so <span class="v-modern">do not</span> know <span class="v-const">not</span> Jesus Christ, nor believe in him, be saved by their living according to the light of nature?
+### Question 60: Can they who have never heard the gospel, and so know not Jesus Christ, nor believe in him, be saved by their living according to the light of nature?
 Answer: <span class="v-const">They</span><span class="v-modern">Those</span> who, having never heard the gospel,<sup class="proof-marker">z</sup> know <span class="v-const">not</span> Jesus Christ,<sup class="proof-marker">a</sup> and <span class="v-modern">do not</span> believe <span class="v-const">not</span> in him, cannot be saved,<sup class="proof-marker">b</sup> <span class="v-const">be they never so diligent</span><span class="v-modern">despite their utmost diligence</span> to frame their lives according to the light of nature,<sup class="proof-marker">c</sup> or the laws of that religion which they profess;<sup class="proof-marker">d</sup> neither is there salvation in any other, but in Christ alone,<sup class="proof-marker">e</sup> who is the Savior only of his body the church.<sup class="proof-marker">f</sup>
 
 <details class="scripture-proofs" id="wlc-q60-proofs">
@@ -688,7 +688,7 @@ Answer: <span class="v-const">They</span><span class="v-modern">Those</span> who
 
 
 <span id="wlc-q61"></span>
-### Question 61: Are all <span class="v-const">they</span> saved <span class="v-const">who</span><span class="v-modern">that</span> hear the gospel, and live in the church?
+### Question 61: Are all they saved who hear the gospel, and live in the church?
 Answer: All that hear the gospel, and live in the visible church, are not saved; but <span class="v-const">they</span> only <span class="v-modern">those</span> who are true members of the church invisible.<sup class="proof-marker">g</sup>
 
 <details class="scripture-proofs" id="wlc-q61-proofs">
@@ -745,7 +745,7 @@ Answer: The members of the invisible church by Christ enjoy union and communion 
 
 
 <span id="wlc-q66"></span>
-### Question 66: What is <span class="v-modern">the union</span> that <span class="v-const">union which</span> the elect have with Christ?
+### Question 66: What is that union which the elect have with Christ?
 Answer: The union <span class="v-const">which</span><span class="v-modern">that</span> the elect have with Christ is the work of God's grace, <span class="v-const">whereby</span><span class="v-modern">by which</span> they are spiritually and mystically, yet really and inseparably, joined to Christ as their head and husband;<sup class="proof-marker">s</sup> which is done in their effectual calling.<sup class="proof-marker">t</sup>
 
 <details class="scripture-proofs" id="wlc-q66-proofs">
@@ -768,7 +768,7 @@ Answer: Effectual calling is the work of God's almighty power and grace,<sup cla
 
 
 <span id="wlc-q68"></span>
-### Question 68: Are <span class="v-modern">only</span> the elect <span class="v-const">only</span> effectually called?
+### Question 68: Are the elect only effectually called?
 Answer: All the elect, and they only, are effectually called;<sup class="proof-marker">b</sup> although others may be, and often are, outwardly called by the ministry of the <span class="v-const">word,</span><span class="v-modern">Word,</span><sup class="proof-marker">c</sup> and have some common operations of the Spirit;<sup class="proof-marker">d</sup> who, for their willful neglect and contempt of the grace offered to them, being justly left in their unbelief, <span class="v-const">do</span> never truly come to Jesus Christ.<sup class="proof-marker">e</sup>
 
 <details class="scripture-proofs" id="wlc-q68-proofs">
@@ -779,7 +779,7 @@ Answer: All the elect, and they only, are effectually called;<sup class="proof-m
 
 
 <span id="wlc-q69"></span>
-### Question 69: What is the communion in grace <span class="v-const">which</span><span class="v-modern">that</span> the members of the invisible church have with Christ?
+### Question 69: What is the communion in grace which the members of the invisible church have with Christ?
 Answer: The communion in grace <span class="v-const">which</span><span class="v-modern">that</span> the members of the invisible church have with Christ, is their partaking of the virtue of his mediation, in their justification,<sup class="proof-marker">f</sup> adoption,<sup class="proof-marker">g</sup> sanctification, and whatever else, in this life, manifests their union with him.<sup class="proof-marker">h</sup>
 
 <details class="scripture-proofs" id="wlc-q69-proofs">
@@ -823,7 +823,7 @@ Answer: Justifying faith is a saving grace,<sup class="proof-marker">u</sup> wro
 
 
 <span id="wlc-q73"></span>
-### Question 73: How <span class="v-const">doth</span><span class="v-modern">does</span> faith justify a sinner in the sight of God?
+### Question 73: How doth faith justify a sinner in the sight of God?
 Answer: Faith justifies a sinner in the sight of God, not because of those other graces <span class="v-const">which do</span><span class="v-modern">that</span> always accompany it, or of good works that are the fruits of it,<sup class="proof-marker">c</sup> nor as if the grace of faith, or any act <span class="v-const">thereof,</span><span class="v-modern">of it,</span> were imputed to him for his justification;<sup class="proof-marker">d</sup> but only as it is an instrument by which he <span class="v-const">receiveth</span><span class="v-modern">receives</span> and <span class="v-const">applieth</span><span class="v-modern">applies</span> Christ and his righteousness.<sup class="proof-marker">e</sup>
 
 <details class="scripture-proofs" id="wlc-q73-proofs">
@@ -868,7 +868,7 @@ Answer: Repentance unto life is a saving grace,<sup cl<span class="v-const">as</
 
 
 <span id="wlc-q77"></span>
-### Question 77: <span class="v-const">Wherein</span><span class="v-modern">How</span> do justification and sanctification differ?
+### Question 77: Wherein do justification and sanctification differ?
 Answer: Although sanctification <span class="v-const">be</span><span class="v-modern">is</span> inseparably joined with justification,<sup class="proof-marker">e</sup> yet they differ, in that God in justification <span class="v-const">imputeth</span><span class="v-modern">imputes</span> the righteousness of Christ;<sup class="proof-marker">f</sup> in sanctification his Spirit <span class="v-const">infuseth</span><span class="v-modern">infuses</span> grace, and <span class="v-const">enableth</span><span class="v-modern">enables</span> to the exercise <span class="v-const">thereof;</span><span class="v-modern">of it;</span><sup class="proof-marker">g</sup> in the former, sin is pardoned;<sup class="proof-marker">h</sup> in the <span class="v-const">other,</span><span class="v-modern">latter,</span> it is subdued:<sup class="proof-marker">i</sup> the one <span class="v-const">doth</span> equally <span class="v-const">free</span><span class="v-modern">frees</span> all believers from the revenging wrath of God, and that perfectly in this life, that they never fall into condemnation; the other is neither equal in all,<sup class="proof-marker">l</sup> nor in this life perfect in any,<sup class="proof-marker">m</sup> but growing up to perfection.<sup class="proof-marker">n</sup>
 
 <details class="scripture-proofs" id="wlc-q77-proofs">
@@ -879,7 +879,7 @@ Answer: Although sanctification <span class="v-const">be</span><span class="v-mo
 
 
 <span id="wlc-q78"></span>
-### Question 78: <span class="v-const">Whence ariseth</span><span class="v-modern">From where does</span> the imperfection of sanctification in <span class="v-const">believers?</span><span class="v-modern">believers arise?</span>
+### Question 78: Whence ariseth the imperfection of sanctification in believers?
 Answer: The imperfection of sanctification in believers <span class="v-const">ariseth</span><span class="v-modern">arises</span> from the remnants of sin abiding in every part of them, and the perpetual <span class="v-const">lustings</span><span class="v-modern">desires</span> of the flesh against the spirit; <span class="v-const">whereby</span><span class="v-modern">by which</span> they are often foiled with temptations, <span class="v-const">and</span> fall into many sins,<sup class="proof-marker">o</sup> are hindered in all their spiritual services,<sup class="proof-marker">p</sup> and their best works are imperfect and defiled in the sight of God.<sup class="proof-marker">q</sup>
 
 <details class="scripture-proofs" id="wlc-q78-proofs">
@@ -890,7 +890,7 @@ Answer: The imperfection of sanctification in believers <span class="v-const">ar
 
 
 <span id="wlc-q79"></span>
-### Question 79: May not true believers, by reason of their imperfections, and the many temptations and sins <span class="v-const">they are overtaken with,</span><span class="v-modern">that overtake them,</span> fall away from the state of grace?
+### Question 79: May not true believers, by reason of their imperfections, and the many temptations and sins they are overtaken with, fall away from the state of grace?
 Answer: True believers, by reason of the unchangeable love of God,<sup class="proof-marker">r</sup> and his decree and covenant to give them perseverance,<sup class="proof-marker">s</sup> their inseparable union with Christ,<sup class="proof-marker">t</sup> his continual intercession for them,<sup class="proof-marker">u</sup> and the Spirit and seed of God abiding in them,<sup class="proof-marker">w</sup> can neither totally nor finally fall away from the state of grace,<sup class="proof-marker">x</sup> but are kept by the power of God through faith <span class="v-const">unto</span><span class="v-modern">to</span> salvation.<sup class="proof-marker">y</sup>
 
 <details class="scripture-proofs" id="wlc-q79-proofs">
@@ -901,7 +901,7 @@ Answer: True believers, by reason of the unchangeable love of God,<sup class="pr
 
 
 <span id="wlc-q80"></span>
-### Question 80: Can true believers be infallibly assured that they are in the <span class="v-const">estate</span><span class="v-modern">state</span> of grace, and that they shall persevere <span class="v-const">therein unto</span><span class="v-modern">in it to</span> salvation?
+### Question 80: Can true believers be infallibly assured that they are in the estate of grace, and that they shall persevere therein unto salvation?
 Answer: <span class="v-const">Such as</span><span class="v-modern">Those who</span> truly believe in Christ, and endeavor to walk in all good conscience before him,<sup class="proof-marker">z</sup> <span class="v-const">may,</span><span class="v-modern">may be infallibly assured that they are in the state of grace and shall persevere in it to salvation,</span> without extraordinary revelation, by faith grounded upon the truth of God's promises, and by the Spirit enabling them to discern in themselves those graces to which the promises of life are made,<sup class="proof-marker">a</sup> and bearing witness with their spirits that they are the children of God,<sup class="proof-marker">b</sup> be infallibly assured that they are in the estate of grace, and shall persevere therein unto salvation.<sup class="proof-marker">c</sup>
 
 <details class="scripture-proofs" id="wlc-q80-proofs">
@@ -912,7 +912,7 @@ Answer: <span class="v-const">Such as</span><span class="v-modern">Those who</sp
 
 
 <span id="wlc-q81"></span>
-### Question 81: Are all true believers at all times assured of their present being in the <span class="v-const">estate</span><span class="v-modern">state</span> of grace, and that they shall be saved?
+### Question 81: Are all true believers at all times assured of their present being in the estate of grace, and that they shall be saved?
 Answer: Assurance of grace and salvation not being of the essence of faith,<sup class="proof-marker">d</sup> true believers may wait long before they obtain it;<sup class="proof-marker">e</sup> and, after the enjoyment <span class="v-const">thereof,</span><span class="v-modern">of it,</span> may have it weakened and intermitted, through manifold <span class="v-const">distempers,</span><span class="v-modern">ailments,</span> sins, temptations, and desertions;<sup class="proof-marker">f</sup> yet <span class="v-const">are they</span><span class="v-modern">they are</span> never left without such a presence and support of the Spirit of God as keeps them from sinking into utter despair.<sup class="proof-marker">g</sup>
 
 <details class="scripture-proofs" id="wlc-q81-proofs">
@@ -923,7 +923,7 @@ Answer: Assurance of grace and salvation not being of the essence of faith,<sup 
 
 
 <span id="wlc-q82"></span>
-### Question 82: What is the communion in glory <span class="v-const">which</span><span class="v-modern">that</span> the members of the invisible church have with Christ?
+### Question 82: What is the communion in glory which the members of the invisible church have with Christ?
 Answer: The communion in glory <span class="v-const">which</span><span class="v-modern">that</span> the members of the invisible church have with Christ, is in this life,<sup class="proof-marker">h</sup> immediately after death,<sup class="proof-marker">i</sup> and at last perfected at the resurrection and day of judgment.
 
 <details class="scripture-proofs" id="wlc-q82-proofs">
@@ -935,7 +935,7 @@ Answer: The communion in glory <span class="v-const">which</span><span class="v-
 
 
 <span id="wlc-q83"></span>
-### Question 83: What is the communion in glory with Christ <span class="v-const">which</span><span class="v-modern">that</span> the members of the invisible church enjoy in this life?
+### Question 83: What is the communion in glory with Christ which the members of the invisible church enjoy in this life?
 Answer: The members of the invisible church have communicated to them in this life the firstfruits of glory with Christ, as they are members of him their head, and so in him <span class="v-const">are interested</span><span class="v-modern">share</span> in that glory which he <span class="v-const">is</span> fully <span class="v-const">possessed of;</span><span class="v-modern">possesses;</span><sup class="proof-marker">l</sup> and, as <span class="v-const">an earnest thereof,</span><span class="v-modern">a guarantee of it,</span> enjoy the sense of God's love, peace of conscience, joy in the Holy <span class="v-const">Ghost,</span><span class="v-modern">Spirit,</span> and hope of glory;<sup class="proof-marker">n</sup> as, on the contrary, sense of God's revenging wrath, horror of conscience, and a fearful expectation of judgment, are to the wicked the beginning of their <span class="v-const">torments</span><span class="v-modern">torments,</span> which they shall endure after death.<sup class="proof-marker">o</sup>
 
 <details class="scripture-proofs" id="wlc-q83-proofs">
@@ -969,7 +969,7 @@ Answer: The righteous shall be delivered from death itself at the last day, and 
 
 
 <span id="wlc-q86"></span>
-### Question 86: What is the communion in glory with Christ <span class="v-const">which</span><span class="v-modern">that</span> the members of the invisible church enjoy immediately after death?
+### Question 86: What is the communion in glory with Christ which the members of the invisible church enjoy immediately after death?
 Answer: The communion in glory with Christ <span class="v-const">which</span><span class="v-modern">that</span> the members of the invisible church enjoy immediately after death, is, <span class="v-const">in</span> that their souls are then made perfect in holiness,<sup class="proof-marker">x</sup> and received into the highest heavens,<sup class="proof-marker">y</sup> where they <span class="v-const">be</span><span class="v-modern">are</span>hold the face of God in light and glory, waiting for the full redemption of their bodies,<sup class="proof-marker">a</sup> which even in death continue united to Christ,<sup class="proof-marker">b</sup> and rest in their graves as in their beds,<sup class="proof-marker">c</sup> till at the last day they be again united to their souls.<sup class="proof-marker">d</sup> <span class="v-const">Whereas</span><span class="v-modern">However,</span> the souls of the wicked are at their death cast into hell, where they remain in torments and utter darkness, and their bodies kept in their graves, as in their prisons, till the resurrection and judgment of the great day.<sup class="proof-marker">e</sup>
 
 <details class="scripture-proofs" id="wlc-q86-proofs">
@@ -1026,7 +1026,7 @@ Answer: At the day of judgment, the righteous, being caught up to Christ in the 
 ## HAVING SEEN WHAT THE SCRIPTURES PRINCIPALLY TEACH US TO BELIEVE CONCERNING GOD, IT FOLLOWS TO CONSIDER WHAT THEY REQUIRE AS THE DUTY OF MAN
 
 <span id="wlc-q91"></span>
-### Question 91: What is the duty <span class="v-const">which</span><span class="v-modern">that</span> God <span class="v-const">requireth</span><span class="v-modern">requires</span> of man?
+### Question 91: What is the duty which God requireth of man?
 Answer: The duty <span class="v-const">which</span><span class="v-modern">that</span> God <span class="v-const">requireth</span><span class="v-modern">requires</span> of man, is obedience to his revealed will.<sup class="proof-marker">z</sup>
 
 <details class="scripture-proofs" id="wlc-q91-proofs">
@@ -1038,7 +1038,7 @@ Answer: The duty <span class="v-const">which</span><span class="v-modern">that</
 
 
 <span id="wlc-q92"></span>
-### Question 92: What did God <span class="v-modern">at</span> first reveal <span class="v-const">unto</span><span class="v-modern">to</span> man as the rule of his obedience?
+### Question 92: What did God first reveal unto man as the rule of his obedience?
 Answer: The rule of obedience revealed to Adam in the <span class="v-const">estate</span><span class="v-modern">state</span> of innocence, and to all mankind in him, besides a special command not to eat of the fruit of the tree of the knowledge of good and evil, was the moral law.<sup class="proof-marker">a</sup>
 
 <details class="scripture-proofs" id="wlc-q92-proofs">
@@ -1106,7 +1106,7 @@ Answer: Although <span class="v-const">they that</span><span class="v-modern">th
 
 
 <span id="wlc-q98"></span>
-### Question 98: Where is the moral law <span class="v-const">summarily comprehended?</span><span class="v-modern">summarized?</span>
+### Question 98: Where is the moral law summarily comprehended?
 Answer: The moral law is <span class="v-const">summarily comprehended</span><span class="v-modern">summarized</span> in the Ten Commandments, which were delivered by the voice of God upon <span class="v-const">mount</span><span class="v-modern">Mount</span> Sinai, and written by him in two tables of stone;<sup class="proof-marker">y</sup> and are recorded in the twentieth chapter of <span class="v-const">Exodus;</span><span class="v-modern">Exodus:</span> the four first commandments containing our duty to God, and the other six our duty to man.<sup class="proof-marker">z</sup>
 
 <details class="scripture-proofs" id="wlc-q98-proofs">
@@ -1151,7 +1151,7 @@ Answer: The preface to the Ten Commandments is contained in these words, I am th
 
 
 <span id="wlc-q102"></span>
-### Question 102: What is the sum of the four commandments <span class="v-const">which</span><span class="v-modern">that</span> contain our duty to God?
+### Question 102: What is the sum of the four commandments which contain our duty to God?
 Answer: The sum of the four commandments containing our duty to God, is, to love the Lord our God with all our heart, and with all our soul, and with all our strength, and with all our mind.<sup class="proof-marker">z</sup>
 
 <details class="scripture-proofs" id="wlc-q102-proofs">
@@ -1241,7 +1241,7 @@ Answer: <span class="v-const"><span class="v-const">The</span></span> sins forbi
 
 
 <span id="wlc-q110"></span>
-### Question 110: What are the reasons annexed to the second commandment, <span class="v-const">the more</span> to enforce <span class="v-const">it?</span><span class="v-modern">it even more?</span>
+### Question 110: What are the reasons annexed to the second commandment, the more to enforce it?
 Answer: The reasons annexed to the second commandment, <span class="v-const">the more</span> to enforce <span class="v-const">it,</span><span class="v-modern">it even more,</span> contained in these words, <span class="v-const">For</span><span class="v-modern">for</span> I the LORD <span class="v-const">thy</span><span class="v-modern">your</span> God am a jealous God, visiting the iniquity of the fathers <span class="v-const">upon</span><span class="v-modern">on</span> the children <span class="v-const">unto</span><span class="v-modern">to</span> the third and <span class="v-modern">the</span> fourth generation of <span class="v-const"><span class="v-const">them that</span><span class="v-modern">those who</span></span><span class="v-modern">those who</span> hate <span class="v-const">me; and shewing mercy unto</span><span class="v-modern">me, but showing steadfast love to</span> thousands of them that love <span class="v-const">me,</span><span class="v-modern">me</span> and keep my commandments;<sup class="proof-marker">o</sup> are, besides God's sovereignty over us, and <span class="v-const">propriety in</span><span class="v-modern">ownership of</span> us,<sup class="proof-marker">p</sup> his fervent zeal for his own worship,<sup class="proof-marker">q</sup> and his revengeful indignation against all false worship, as being a spiritual whoredom;<sup class="proof-marker">r</sup> accounting the breakers of this commandment <span class="v-const">such</span> as <span class="v-modern">those who</span> hate him, and threatening to punish them <span class="v-const"><span class="v-const">unto</span><span class="v-modern">to</span> divers</span><span class="v-modern">to several</span> generations;<sup class="proof-marker">s</sup> and esteeming the observers of it <span class="v-const">such</span> as <span class="v-modern">those who</span> love him and keep his commandments, and promising mercy to them unto many generations.<sup class="proof-marker">t</sup>
 
 <details class="scripture-proofs" id="wlc-q110-proofs">
@@ -1355,7 +1355,7 @@ Answer: The sins forbidden in the fourth commandment are, all omissions of the d
 
 
 <span id="wlc-q120"></span>
-### Question 120: What are the reasons annexed to the fourth commandment, <span class="v-const">the more</span> to enforce <span class="v-const">it?</span><span class="v-modern">it even more?</span>
+### Question 120: What are the reasons annexed to the fourth commandment, the more to enforce it?
 Answer: The reasons annexed to the fourth commandment, <span class="v-const">the more</span> to enforce <span class="v-const">it,</span><span class="v-modern">it even more,</span> are taken from the equity of it, God allowing us six days of seven for our own affairs, and reserving <span class="v-const">but</span><span class="v-modern">only</span> one for himself, in these words, Six days <span class="v-const">shalt thou</span><span class="v-modern">you shall</span> labor, and do all <span class="v-const">thy</span><span class="v-modern">your</span> work:<sup class="proof-marker">x</sup> from God's <span class="v-const">challenging</span><span class="v-modern">claiming</span> a special <span class="v-const">propriety in</span><span class="v-modern">ownership of</span> that day, <span class="v-const">The</span><span class="v-modern">the</span> seventh day is <span class="v-const">the sabbath of</span><span class="v-modern">a Sabbath to</span> the LORD <span class="v-const">thy</span><span class="v-modern">your</span> God:<sup class="proof-marker">y</sup> from the example of God, who in six days <span class="v-const">...</span><span class="v-modern">…</span> made heaven and earth, the sea, and all that <span class="v-modern">is</span> in <span class="v-const">them is,</span><span class="v-modern">them,</span> and rested <span class="v-modern">on</span> the seventh day: and from that blessing which God put upon that day, not only in sanctifying it to be a day for his service, but in ordaining it to be a means of blessing to us in our sanctifying it; <span class="v-const">Wherefore</span><span class="v-modern">Therefore</span> the LORD blessed the <span class="v-const">sabbath day,</span><span class="v-modern">Sabbath day</span> and <span class="v-const">hallowed it.</span><span class="v-modern">made it holy.</span><sup class="proof-marker">z</sup>
 
 <details class="scripture-proofs" id="wlc-q120-proofs">
@@ -1378,7 +1378,7 @@ Answer: The word Remember is set in the beginning of the fourth commandment,<sup
 
 
 <span id="wlc-q122"></span>
-### Question 122: What is the sum of the six commandments <span class="v-const">which</span><span class="v-modern">that</span> contain our duty to man?
+### Question 122: What is the sum of the six commandments which contain our duty to man?
 Answer: The sum of the six commandments <span class="v-const">which</span><span class="v-modern">that</span> contain our duty to man, is, to love our neighbor as ourselves, and to do to others what we would have them <span class="v-modern">to</span> do to us.<sup class="proof-marker">l</sup>
 
 <details class="scripture-proofs" id="wlc-q122-proofs">
@@ -1413,7 +1413,7 @@ Answer: By father and mother, in the fifth commandment, are meant, not only natu
 
 
 <span id="wlc-q125"></span>
-### Question 125: Why are superiors <span class="v-const">styled Father</span><span class="v-modern">called father</span> and <span class="v-const">Mother?</span><span class="v-modern">mother?</span>
+### Question 125: Why are superiors styled Father and Mother?
 Answer: Superiors are <span class="v-const">styled Father</span><span class="v-modern">called father</span> and <span class="v-const">Mother,</span><span class="v-modern">mother,</span> both to teach them in all duties toward their inferiors, like natural parents, to express love and tenderness to them, according to their several relations;<sup class="proof-marker">t</sup> and to <span class="v-const">work</span><span class="v-modern">move</span> inferiors to a greater willingness and cheerfulness in performing their duties to their superiors, as to their parents.<sup class="proof-marker">u</sup>
 
 <details class="scripture-proofs" id="wlc-q125-proofs">
@@ -1504,7 +1504,7 @@ Answer: The sins of equals are, besides the neglect of the duties required,<sup 
 
 
 <span id="wlc-q133"></span>
-### Question 133: What is the reason annexed to the fifth commandment, <span class="v-const">the more</span> to enforce <span class="v-const">it?</span><span class="v-modern">it even more?</span>
+### Question 133: What is the reason annexed to the fifth commandment, the more to enforce it?
 Answer: The reason annexed to the fifth commandment, in these words, <span class="v-const">That thy</span><span class="v-modern">that your</span> days may be long <span class="v-const">upon</span><span class="v-modern">in</span> the land <span class="v-const">which</span><span class="v-modern">that</span> the LORD <span class="v-const">thy</span><span class="v-modern">your</span> God <span class="v-const">giveth thee,</span><span class="v-modern">is giving you,</span> is an express promise of long life and prosperity, as far as it shall serve for God's glory and their own good, to all <span class="v-const">such as</span><span class="v-modern">those who</span> keep this commandment.<sup class="proof-marker">l</sup>
 
 <details class="scripture-proofs" id="wlc-q133-proofs">
@@ -1724,7 +1724,7 @@ Answer: Sins receive their aggravations,
 
 
 <span id="wlc-q152"></span>
-### Question 152: What <span class="v-const">doth</span><span class="v-modern">does</span> every sin deserve at the hands of God?
+### Question 152: What doth every sin deserve at the hands of God?
 Answer: Every sin, even the least, being against the sovereignty,<sup class="proof-marker">m</sup> goodness,<sup class="proof-marker">n</sup> and holiness of God,<sup class="proof-marker">o</sup> and against his righteous law,<sup class="proof-marker">p</sup> <span class="v-const">deserveth</span><span class="v-modern">deserves</span> his wrath and curse,<sup class="proof-marker">q</sup> both in this life,<sup class="proof-marker">r</sup> and that which is to come;<sup class="proof-marker">s</sup> and cannot be expiated <span class="v-const">but</span><span class="v-modern">except</span> by the blood of Christ.<sup class="proof-marker">t</sup>
 
 <details class="scripture-proofs" id="wlc-q152-proofs">
@@ -1735,7 +1735,7 @@ Answer: Every sin, even the least, being against the sovereignty,<sup class="pro
 
 
 <span id="wlc-q153"></span>
-### Question 153: What <span class="v-const">doth</span><span class="v-modern">does</span> God require of us, that we may escape his wrath and curse due to us by reason of the transgression of the law?
+### Question 153: What doth God require of us, that we may escape his wrath and curse due to us by reason of the transgression of the law?
 Answer: That we may escape the wrath and curse of God due to us by reason of the transgression of the law, he <span class="v-const">requireth</span><span class="v-modern">requires</span> of us repentance toward God, and faith toward our Lord Jesus Christ,<sup class="proof-marker">u</sup> and the diligent use of the outward means <span class="v-const">whereby</span><span class="v-modern">by which</span> Christ communicates to us the benefits of his mediation.<sup class="proof-marker">w</sup>
 
 <details class="scripture-proofs" id="wlc-q153-proofs">
@@ -1746,7 +1746,7 @@ Answer: That we may escape the wrath and curse of God due to us by reason of the
 
 
 <span id="wlc-q154"></span>
-### Question 154: What are the outward means <span class="v-const">whereby</span><span class="v-modern">by which</span> Christ communicates to us the benefits of his mediation?
+### Question 154: What are the outward means whereby Christ communicates to us the benefits of his mediation?
 Answer: The outward and ordinary means <span class="v-const">whereby</span><span class="v-modern">by which</span> Christ communicates to his church the benefits of his mediation, are all his ordinances; especially the <span class="v-const">word,</span><span class="v-modern">Word,</span> sacraments, and prayer; all <span class="v-modern">of</span> which are made effectual to the elect for their salvation.<sup class="proof-marker">x</sup>
 
 <details class="scripture-proofs" id="wlc-q154-proofs">
@@ -1802,7 +1802,7 @@ Answer: The Word of God is to be preached only by <span class="v-const">such as<
 
 
 <span id="wlc-q159"></span>
-### Question 159: How is the Word of God to be preached by those that are called <span class="v-const">thereunto?</span><span class="v-modern">to that office?</span>
+### Question 159: How is the Word of God to be preached by those that are called thereunto?
 Answer: <span class="v-const">They that</span><span class="v-modern">Those who</span> are called to labor in the ministry of the <span class="v-const">word,</span><span class="v-modern">Word,</span> are to preach sound doctrine,<sup class="proof-marker">y</sup> diligently,<sup class="proof-marker">z</sup> in season and out of season;<sup class="proof-marker">a</sup> plainly,<sup class="proof-marker">b</sup> not in the enticing words of man's wisdom, but in demonstration of the Spirit, and of power;<sup class="proof-marker">c</sup> faithfully,<sup class="proof-marker">d</sup> making known the whole counsel of God;<sup class="proof-marker">e</sup> wisely,<sup class="proof-marker">f</sup> applying themselves to the necessities and capacities of the hearers;<sup class="proof-marker">g</sup> zealously,<sup class="proof-marker">h</sup> with fervent love to God and the souls of his people; sincerely,<sup class="proof-marker">l</sup> aiming at his glory,<sup class="proof-marker">m</sup> and their conversion,<sup class="proof-marker">n</sup> edification,<sup class="proof-marker">o</sup> and salvation.<sup class="proof-marker">p</sup>
 
 <details class="scripture-proofs" id="wlc-q159-proofs">
@@ -1859,7 +1859,7 @@ Answer: The parts of a sacrament are two; the one an outward and sensible <span 
 
 
 <span id="wlc-q164"></span>
-### Question 164: How many sacraments <span class="v-const">hath</span><span class="v-modern">has</span> Christ instituted in his church under the <span class="v-const">New Testament?</span><span class="v-modern">new testament?</span>
+### Question 164: How many sacraments hath Christ instituted in his church under the New Testament?
 Answer: Under the <span class="v-const">New Testament</span><span class="v-modern">new testament</span> Christ <span class="v-const">hath</span><span class="v-modern">has</span> instituted in his church only two sacraments, baptism and the Lord's <span class="v-const">supper.</span><span class="v-modern">Supper.</span>
 
 <details class="scripture-proofs" id="wlc-q164-proofs">
@@ -1882,7 +1882,7 @@ Answer: Baptism is a sacrament of the <span class="v-const">New Testament, where
 
 
 <span id="wlc-q166"></span>
-### Question 166: <span class="v-const">Unto</span><span class="v-modern">To</span> whom is baptism to be administered?
+### Question 166: Unto whom is baptism to be administered?
 Answer: Baptism is not to be administered to any that are out of the visible church, and so strangers from the covenant of promise, till they profess their faith in Christ, and obedience to him,<sup class="proof-marker">z</sup> but infants descending from parents, either <span class="v-const">both,</span><span class="v-modern">both</span> or <span class="v-const">but</span><span class="v-modern">only</span> one of them, professing faith in Christ, and obedience to him, are in that respect within the covenant, and to be baptized.<sup class="proof-marker">a</sup>
 
 <details class="scripture-proofs" id="wlc-q166-proofs">
@@ -1915,7 +1915,7 @@ Answer: The Lord's <span class="v-const">supper</span><span class="v-modern">Sup
 
 
 <span id="wlc-q169"></span>
-### Question 169: How <span class="v-const">hath</span><span class="v-modern">has</span> Christ appointed bread and wine to be given and received in the sacrament of the Lord's <span class="v-const">supper?</span><span class="v-modern">Supper?</span>
+### Question 169: How hath Christ appointed bread and wine to be given and received in the sacrament of the Lord's supper?
 Answer: Christ <span class="v-const">hath</span><span class="v-modern">has</span> appointed the ministers of his <span class="v-const">word,</span><span class="v-modern">Word,</span> in the administration of this sacrament of the Lord's <span class="v-const">supper,</span><span class="v-modern">Supper,</span> to set apart the bread and wine from common use, by the word of institution, thanksgiving, and prayer; to take and break the bread, and to give both the bread and the wine to the communicants: who are, by the same appointment, to take and eat the bread, and to drink the wine, in thankful remembrance that the body of Christ was broken and given, and his blood shed, for them.<sup class="proof-marker">r</sup>
 
 <details class="scripture-proofs" id="wlc-q169-proofs">
@@ -1927,7 +1927,7 @@ Answer: Christ <span class="v-const">hath</span><span class="v-modern">has</span
 
 
 <span id="wlc-q170"></span>
-### Question 170: How do <span class="v-const">they that</span><span class="v-modern">those who</span> worthily <span class="v-const">communicate in</span><span class="v-modern">partake of</span> the Lord's <span class="v-const">supper</span><span class="v-modern">Supper</span> feed upon the body and blood of Christ <span class="v-const">therein?</span><span class="v-modern">in it?</span>
+### Question 170: How do they that worthily communicate in the Lord's supper feed upon the body and blood of Christ therein?
 Answer: As the body and blood of Christ are not corporally or carnally present in, with, or under the bread and wine in the Lord's <span class="v-const">supper,</span><span class="v-modern">Supper,</span> and yet are spiritually present to the faith of the receiver, no less truly and really than the elements themselves are to their outward senses;<sup class="proof-marker">t</sup> so <span class="v-const">they that</span><span class="v-modern">those who</span> worthily <span class="v-const">communicate in</span><span class="v-modern">partake of</span> the sacrament of the Lord's <span class="v-const">supper, do therein</span><span class="v-modern">Supper</span> feed upon the body and blood of <span class="v-const">Christ,</span><span class="v-modern">Christ in it,</span> not <span class="v-const">after</span><span class="v-modern">in</span> a corporal and carnal, but in a spiritual manner; yet truly and really,<sup class="proof-marker">u</sup> while by faith they receive and apply <span class="v-const">unto</span><span class="v-modern">to</span> themselves Christ crucified, and all the benefits of his death.<sup class="proof-marker">w</sup>
 
 <details class="scripture-proofs" id="wlc-q170-proofs">
@@ -1938,7 +1938,7 @@ Answer: As the body and blood of Christ are not corporally or carnally present i
 
 
 <span id="wlc-q171"></span>
-### Question 171: How are <span class="v-const">they that</span><span class="v-modern">those who</span> receive the sacrament of the Lord's <span class="v-const">supper</span><span class="v-modern">Supper</span> to prepare themselves before they come <span class="v-const">unto</span><span class="v-modern">to</span> it?
+### Question 171: How are they that receive the sacrament of the Lord's supper to prepare themselves before they come unto it?
 Answer: <span class="v-const">They that</span><span class="v-modern">Those who</span> receive the sacrament of the Lord's <span class="v-const">supper</span><span class="v-modern">Supper</span> are, before they come, to prepare themselves <span class="v-const">thereunto,</span><span class="v-modern">for it,</span> by examining themselves of their being in Christ,<sup class="proof-marker">y</sup> of their sins and <span class="v-const">wants;</span><span class="v-modern">failures;</span><sup class="proof-marker">z</sup> of the truth and measure of their knowledge,<sup class="proof-marker">a</sup> faith,<sup class="proof-marker">b</sup> repentance;<sup class="proof-marker">c</sup> love to God and the <span class="v-const">brethren,</span><span class="v-modern">brothers,</span><sup class="proof-marker">d</sup> charity to all men,<sup class="proof-marker">e</sup> forgiving those that have done them wrong;<sup class="proof-marker">f</sup> of their desires after Christ,<sup class="proof-marker">g</sup> and of their new obedience;<sup class="proof-marker">h</sup> and by renewing the exercise of these graces,<sup class="proof-marker">i</sup> by serious meditation, and fervent prayer.<sup class="proof-marker">l</sup>
 
 <details class="scripture-proofs" id="wlc-q171-proofs">
@@ -1949,7 +1949,7 @@ Answer: <span class="v-const">They that</span><span class="v-modern">Those who</
 
 
 <span id="wlc-q172"></span>
-### Question 172: May one who <span class="v-const">doubteth</span><span class="v-modern">doubts</span> of his being in Christ, or of his due preparation, come to the Lord's <span class="v-const">supper?</span><span class="v-modern">Supper?</span>
+### Question 172: May one who doubteth of his being in Christ, or of his due preparation, come to the Lord's supper?
 Answer: One who <span class="v-const">doubteth</span><span class="v-modern">doubts</span> of his being in Christ, or of his due preparation <span class="v-const">to</span><span class="v-modern">for</span> the sacrament of the Lord's <span class="v-const"><span class="v-const">supper,</span><span class="v-modern">Supper,</span></span><span class="v-modern">Supper,</span> may have true interest in Christ, though he <span class="v-const"><span class="v-const">be</span><span class="v-modern">is</span></span><span class="v-modern">is</span> not yet assured <span class="v-const">thereof;</span><span class="v-modern">of it;</span><sup class="proof-marker">m</sup> and in God's account <span class="v-const">hath</span><span class="v-modern">has</span> it, if he be duly affected with the apprehension of the <span class="v-const">want</span><span class="v-modern">lack</span> of it,<sup class="proof-marker">n</sup> and <span class="v-const">unfeignedly</span><span class="v-modern">genuinely</span> desires to be found in Christ,<sup class="proof-marker">o</sup> and to depart from iniquity:<sup class="proof-marker">p</sup> in <span class="v-const">which</span><span class="v-modern">that</span> case (because promises are made, and this sacrament is appointed, for the relief even of weak and doubting Christians) he is to <span class="v-const">bewail</span><span class="v-modern">lament</span> his unbelief,<sup class="proof-marker">r</sup> and labor to have his doubts resolved;<sup class="proof-marker">s</sup> and, so doing, he may and ought to come to the Lord's supper, that he may be further strengthened.<sup class="proof-marker">t</sup>
 
 <details class="scripture-proofs" id="wlc-q172-proofs">
@@ -1972,7 +1972,7 @@ Answer: <span class="v-const">Such as</span><span class="v-modern">Those who</sp
 
 
 <span id="wlc-q174"></span>
-### Question 174: What is required of <span class="v-const">them that</span><span class="v-modern">those who</span> receive the sacrament of the Lord's <span class="v-const">supper</span><span class="v-modern">Supper</span> in the time of the administration of it?
+### Question 174: What is required of them that receive the sacrament of the Lord's supper in the time of the administration of it?
 Answer: It is required of <span class="v-const">them that</span><span class="v-modern">those who</span> receive the sacrament of the Lord's <span class="v-const">supper,</span><span class="v-modern">Supper,</span> that, during the time of the administration of it, with all holy reverence and attention they wait upon God in that ordinance,<sup class="proof-marker">x</sup> diligently observe the sacramental elements and actions,<sup class="proof-marker">y</sup> heedfully discern the Lord's body, and affectionately meditate on his death and sufferings,<sup class="proof-marker">a</sup> and <span class="v-const">thereby</span><span class="v-modern">in this way</span> stir <span class="v-const">up themselves</span><span class="v-modern">themselves up</span> to a vigorous exercise of their graces;<sup class="proof-marker">b</sup> in judging themselves,<sup class="proof-marker">c</sup> and sorrowing for sin;<sup class="proof-marker">d</sup> in earnest hungering and thirsting after Christ,<sup class="proof-marker">e</sup> feeding on him by faith,<sup class="proof-marker">f</sup> receiving of his fullness,<sup class="proof-marker">g</sup> trusting in his merits,<sup class="proof-marker">h</sup> rejoicing in his love, giving thanks for his grace; in renewing of their covenant with God,<sup class="proof-marker">l</sup> and love to all the saints.<sup class="proof-marker">m</sup>
 
 <details class="scripture-proofs" id="wlc-q174-proofs">
@@ -1994,7 +1994,7 @@ Answer: The duty of Christians, after they have received the sacrament of the Lo
 
 
 <span id="wlc-q176"></span>
-### Question 176: <span class="v-const">Wherein</span><span class="v-modern">How</span> do the sacraments of baptism and the Lord's <span class="v-const">supper</span><span class="v-modern">Supper</span> agree?
+### Question 176: Wherein do the sacraments of baptism and the Lord's supper agree?
 Answer: The sacraments of baptism and the Lord's supper agree, in that the author of both is God;<sup class="proof-marker">y</sup> the spiritual part of both is Christ and his benefits;<sup class="proof-marker">z</sup> both are seals of the same covenant,<sup class="proof-marker">a</sup> are to be dispensed by ministers of the gospel, and by none other;<sup class="proof-marker">b</sup> and to be continued in the church of Christ until his second coming.<sup class="proof-marker">c</sup>
 
 <details class="scripture-proofs" id="wlc-q176-proofs">
@@ -2005,7 +2005,7 @@ Answer: The sacraments of baptism and the Lord's supper agree, in that the autho
 
 
 <span id="wlc-q177"></span>
-### Question 177: <span class="v-const">Wherein</span><span class="v-modern">How</span> do the sacraments of baptism and the Lord's <span class="v-const">supper</span><span class="v-modern">Supper</span> differ?
+### Question 177: Wherein do the sacraments of baptism and the Lord's supper differ?
 Answer: The sacraments of baptism and the Lord's <span class="v-const"><span class="v-const">supper</span><span class="v-modern">Supper</span></span><span class="v-modern">Supper</span> differ, in that baptism is to be administered <span class="v-const">but</span><span class="v-modern">only</span> once, with water, to be a sign and seal of our regeneration and ingrafting into Christ,<sup class="proof-marker">d</sup> and that even to infants;<sup class="proof-marker">e</sup> <span class="v-const">whereas</span><span class="v-modern">but</span> the Lord's supper is to be administered often, in the elements of bread and wine, to represent and exhibit <span class="v-modern">4</span> Christ as spiritual nourishment to the soul,<sup class="proof-marker">f</sup> and to confirm our continuance and growth in him,<sup class="proof-marker">g</sup> and that only to <span class="v-const">such as</span><span class="v-modern">those who</span> are of years and ability to examine themselves.<sup class="proof-marker">h</sup>
 
 <details class="scripture-proofs" id="wlc-q177-proofs">
@@ -2028,7 +2028,7 @@ Answer: Prayer is an offering up of our desires <span class="v-const">unto</span
 
 
 <span id="wlc-q179"></span>
-### Question 179: Are we to pray <span class="v-const">unto</span><span class="v-modern">to</span> God only?
+### Question 179: Are we to pray unto God only?
 Answer: God only being able to search the hearts,<sup class="proof-marker">o</sup> hear the requests,<sup class="proof-marker">p</sup> pardon the sins,<sup class="proof-marker">q</sup> and fulfill the desires of all;<sup class="proof-marker">r</sup> and only to be believed in,<sup class="proof-marker">s</sup> and worshiped with religious worship;<sup class="proof-marker">t</sup> prayer, which is a special part <span class="v-const">thereof,</span><span class="v-modern">of it,</span><sup class="proof-marker">u</sup> is to be made by all to him alone,<sup class="proof-marker">w</sup> and to none other.<sup class="proof-marker">x</sup>
 
 <details class="scripture-proofs" id="wlc-q179-proofs">
@@ -2062,7 +2062,7 @@ Answer: The sinfulness of man, <span class="v-const">and</span><span class="v-mo
 
 
 <span id="wlc-q182"></span>
-### Question 182: How <span class="v-const">doth</span><span class="v-modern">does</span> the Spirit help us to pray?
+### Question 182: How doth the Spirit help us to pray?
 Answer: We not knowing what to pray for as we ought, the Spirit <span class="v-const">helpeth</span><span class="v-modern">helps</span> our infirmities, by enabling us to understand both for whom, and what, and how prayer is to be made; and by working and <span class="v-const">quickening</span><span class="v-modern">making alive</span> in our hearts (although not in all persons, nor at all times, in the same measure) those apprehensions, affections, and graces <span class="v-const">which</span><span class="v-modern">that</span> are requisite for the right performance of that duty.<sup class="proof-marker">e</sup>
 
 <details class="scripture-proofs" id="wlc-q182-proofs">
@@ -2107,7 +2107,7 @@ Answer: We are to pray with an <span class="v-const">awful</span><span class="v-
 
 
 <span id="wlc-q186"></span>
-### Question 186: What rule <span class="v-const">hath</span><span class="v-modern">has</span> God given for our direction in the duty of prayer?
+### Question 186: What rule hath God given for our direction in the duty of prayer?
 Answer: The whole Word of God is of use to direct us in the duty of prayer;<sup class="proof-marker">m</sup> but the special rule of direction is that form of prayer which our Savior Christ taught his disciples, commonly called The Lord's prayer.
 
 <details class="scripture-proofs" id="wlc-q186-proofs">
@@ -2130,11 +2130,11 @@ Answer: The Lord's <span class="v-const">prayer</span><span class="v-modern">Pra
 
 
 <span id="wlc-q188"></span>
-### Question 188: Of how many parts <span class="v-const">doth</span><span class="v-modern">does</span> the Lord's <span class="v-const">prayer</span><span class="v-modern">Prayer</span> consist?
+### Question 188: Of how many parts doth the Lord's prayer consist?
 Answer: The Lord's prayer consists of three parts; a preface, petitions, and a conclusion.
 
 <span id="wlc-q189"></span>
-### Question 189: What <span class="v-const">doth</span><span class="v-modern">does</span> the preface of the Lord's <span class="v-const">prayer</span><span class="v-modern">Prayer</span> teach us?
+### Question 189: What doth the preface of the Lord's prayer teach us?
 Answer: The preface of the Lord's <span cl<span class="v-const">as</span><span class="v-modern">and</span>s="v-const">prayer</span><span class="v-modern">Prayer</span> (contained in these words, Our Father <span class="v-const">which art</span> in <span class="v-const">heaven) teacheth</span><span class="v-modern">heaven,) teaches</span> us, when we pray, to draw near to God with confidence <span class="v-const">of</span><span class="v-modern">in</span> his fatherly goodness, and our interest <span class="v-const">therein;</span><span class="v-modern">in it;</span><sup class="proof-marker">q</sup> with reverence, and all other childlike dispositions,<sup class="proof-marker">r</sup> heavenly affections,<sup class="proof-marker">s</sup> and due apprehensions of his sovereign power, majesty, and gracious condescension:<sup class="proof-marker">t</sup> as also, to pray with and for others.<sup class="proof-marker">u</sup>
 
 <details class="scripture-proofs" id="wlc-q189-proofs">
@@ -2211,7 +2211,7 @@ Answer: In the sixth <span class="v-const">petition</span><span class="v-modern"
 
 
 <span id="wlc-q196"></span>
-### Question 196: What <span class="v-const">doth</span><span class="v-modern">does</span> the conclusion of the Lord's <span class="v-const">prayer</span><span class="v-modern">Prayer</span> teach us?
+### Question 196: What doth the conclusion of the Lord's prayer teach us?
 Answer: The conclusion of the Lord's <span class="v-const">prayer</span><span class="v-modern">Prayer,</span> (which is, For <span class="v-const">thine</span><span class="v-modern">yours</span> is the <span class="v-const">kingdom,</span><span class="v-modern">kingdom</span> and the <span class="v-const">power,</span><span class="v-modern">power</span> and the glory, forever. Amen.) <span class="v-const">teacheth</span><span class="v-modern">teaches</span> us to <span class="v-const">enforce</span><span class="v-modern">support</span> our petitions with arguments,<sup class="proof-marker">o</sup> which are to be taken, not from any worthiness in ourselves, or in any other creature, but from God;<sup class="proof-marker">p</sup> and with our prayers to join praises,<sup class="proof-marker">q</sup> ascribing to God alone eternal sovereignty, <span class="v-const">omnipotency,</span><span class="v-modern">omnipotence,</span> and glorious excellency;<sup class="proof-marker">r</sup> in <span class="v-const">regard whereof,</span><span class="v-modern">this regard,</span> as he is able and willing to help us,<sup class="proof-marker">s</sup> so we by faith are emboldened to plead with him that he would,<sup class="proof-marker">t</sup> and quietly to rely upon him, that he will fulfill our requests.<sup class="proof-marker">u</sup> And, to testify this our desire and assurance, we say, <span class="v-const">Amen</span><span class="v-modern">Amen.</span>
 
 <details class="scripture-proofs" id="wlc-q196-proofs">

--- a/_pages/wsc.md
+++ b/_pages/wsc.md
@@ -13,7 +13,7 @@ Answer: Man's chief end is to glorify God,<sup class="proof-marker">a</sup> and 
 <details class="scripture-proofs" id="wsc-q1-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Ps. 86:9; Isa. 60:21; Rom. 11:36; 1 Cor. 6:20; 1 Cor. 10:31; Rev. 4:11, <strong>b.</strong> Ps. 16:5–11; Ps. 144:15; Isa. 12:2; Luke 2:10; Phil. 4:4; Rev. 21:3–4</p></div>
+<p><strong>a.</strong> Ps. 86:9; Isa. 60:21; Rom. 11:36; 1 Cor. 6:20; 1 Cor. 10:31; Rev. 4:11, <strong>b.</strong> Ps. 16:5-11; Ps. 144:15; Isa. 12:2; Luke 2:10; Phil. 4:4; Rev. 21:3-4</p></div>
 </details>
 
 
@@ -24,7 +24,7 @@ Answer: The Word of God, which is contained in the Scriptures of the Old and New
 <details class="scripture-proofs" id="wsc-q2-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>c.</strong> Matt. 19:4–5; Gen. 2:24; Luke 24:27, 44; 1 Cor. 2:13; 1 Cor. 14:37; 2 Pet. 1:20–21; 2 Pet. 3:2, 15–16, <strong>d.</strong> Deut. 4:2; Ps. 19:7–11; Isa. 8:20; John 15:11; John 20:30–31; Acts 17:11; 2 Tim. 3:15–17</p></div>
+<p><strong>c.</strong> Matt. 19:4-5; Gen. 2:24; Luke 24:27, 44; 1 Cor. 2:13; 1 Cor. 14:37; 2 Pet. 1:20-21; 2 Pet. 3:2, 15-16, <strong>d.</strong> Deut. 4:2; Ps. 19:7-11; Isa. 8:20; John 15:11; John 20:30-31; Acts 17:11; 2 Tim. 3:15-17</p></div>
 </details>
 
 
@@ -47,7 +47,7 @@ Answer: God is a Spirit,<sup class="proof-marker">g</sup> infinite,<sup class="p
 <details class="scripture-proofs" id="wsc-q4-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>e.</strong> Gen. 1:1; John 5:39; John 20:31; Rom. 10:17; 2 Tim. 3:15, <strong>f.</strong> Deut. 10:12–13; Josh. 1:8; Ps. 119:105; Mic. 6:8; 2 Tim. 3:16–17, <strong>g.</strong> Deut. 4:15–19; Luke 24:39; John 1:18; John 4:24; Acts 17:29, <strong>h.</strong> 1 Kings 8:27; Ps. 139:7–10; Ps. 145:3; Ps. 147:5; Jer. 23:24; Rom. 11:33–36, <strong>i.</strong> Deut. 33:27; Ps. 90:2; Ps. 102:12, 24–27; Rev. 1:4, 8; Ps. 33:11; Mal. 3:6; Heb. 1:12; Heb. 6:17; Heb. 13:8, <strong>l.</strong> Ps. 115:2–3; 1 Tim. 1:17, <strong>m.</strong> Ps. 104:24; Rom. 11:33–34; Heb. 4:13; 1 John 3:20, <strong>n.</strong> Gen. 17:1; Ps. 62:11; Jer. 32:17; Matt. 19:26; Rev. 1:8, <strong>o.</strong> Hab. 1:13; 1 Pet. 1:15–16; 1 John 3:3, 5; Rev. 15:4, <strong>p.</strong> Gen. 18:25; Deut. 32:4; Ps. 96:13; Rom. 3:5, 26, <strong>q.</strong> Ps. 103:5; Ps. 107:8; Matt. 19:17</p></div>
+<p><strong>e.</strong> Gen. 1:1; John 5:39; John 20:31; Rom. 10:17; 2 Tim. 3:15, <strong>f.</strong> Deut. 10:12-13; Josh. 1:8; Ps. 119:105; Mic. 6:8; 2 Tim. 3:16-17, <strong>g.</strong> Deut. 4:15-19; Luke 24:39; John 1:18; John 4:24; Acts 17:29, <strong>h.</strong> 1 Kings 8:27; Ps. 139:7-10; Ps. 145:3; Ps. 147:5; Jer. 23:24; Rom. 11:33-36, <strong>i.</strong> Deut. 33:27; Ps. 90:2; Ps. 102:12, 24-27; Rev. 1:4, 8; Ps. 33:11; Mal. 3:6; Heb. 1:12; Heb. 6:17; Heb. 13:8, <strong>l.</strong> Ps. 115:2-3; 1 Tim. 1:17, <strong>m.</strong> Ps. 104:24; Rom. 11:33-34; Heb. 4:13; 1 John 3:20, <strong>n.</strong> Gen. 17:1; Ps. 62:11; Jer. 32:17; Matt. 19:26; Rev. 1:8, <strong>o.</strong> Hab. 1:13; 1 Pet. 1:15-16; 1 John 3:3, 5; Rev. 15:4, <strong>p.</strong> Gen. 18:25; Deut. 32:4; Ps. 96:13; Rom. 3:5, 26, <strong>q.</strong> Ps. 103:5; Ps. 107:8; Matt. 19:17</p></div>
 </details>
 
 
@@ -70,7 +70,7 @@ Answer: There are three persons in the <span class="v-const">Godhead:</span><spa
 <details class="scripture-proofs" id="wsc-q6-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>r.</strong> Deut. 32:4; Ps. 86:15; Ps. 117:2; Heb. 6:18, <strong>s.</strong> Deut. 6:4; Isa. 44:6; Isa. 45:21–22; 1 Cor. 8:4–6, <strong>t.</strong> Jer. 10:10; John 17:3; 1 Thess. 1:9; 1 John 5:20, <strong>u.</strong> Matt. 3:16–17; Matt. 28:19</p></div>
+<p><strong>r.</strong> Deut. 32:4; Ps. 86:15; Ps. 117:2; Heb. 6:18, <strong>s.</strong> Deut. 6:4; Isa. 44:6; Isa. 45:21-22; 1 Cor. 8:4-6, <strong>t.</strong> Jer. 10:10; John 17:3; 1 Thess. 1:9; 1 John 5:20, <strong>u.</strong> Matt. 3:16-17; Matt. 28:19</p></div>
 </details>
 
 
@@ -93,7 +93,7 @@ Answer: God <span class="v-const">executeth</span><span class="v-modern">execute
 <details class="scripture-proofs" id="wsc-q8-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>w.</strong> Ps. 45:6; John 1:1; John 17:5; Acts 5:3–4; Rom. 9:5; Col. 2:9, <strong>x.</strong> Ps. 33:11; Isa. 14:24; Acts 2:23; Eph. 1:11–12, <strong>y.</strong> Ps. 148:8; Isa. 40:26; Dan. 4:35; Acts 4:24–28</p></div>
+<p><strong>w.</strong> Ps. 45:6; John 1:1; John 17:5; Acts 5:3-4; Rom. 9:5; Col. 2:9, <strong>x.</strong> Ps. 33:11; Isa. 14:24; Acts 2:23; Eph. 1:11-12, <strong>y.</strong> Ps. 148:8; Isa. 40:26; Dan. 4:35; Acts 4:24-28</p></div>
 </details>
 
 
@@ -163,7 +163,7 @@ Answer: Sin is any <span class="v-const">want</span><span class="v-modern">lack<
 <details class="scripture-proofs" id="wsc-q14-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Ps. 36:6; Prov. 16:33; Matt. 10:30, <strong>m.</strong> Gen. 2:16–17, <strong>n.</strong> Gen. 3:6–8, 13; 2 Cor. 11:3, <strong>o.</strong> Lev. 5:17</p></div>
+<p><strong>l.</strong> Ps. 36:6; Prov. 16:33; Matt. 10:30, <strong>m.</strong> Gen. 2:16-17, <strong>n.</strong> Gen. 3:6-8, 13; 2 Cor. 11:3, <strong>o.</strong> Lev. 5:17</p></div>
 </details>
 
 
@@ -198,7 +198,7 @@ Answer: The fall brought <span class="v-const">mankind</span><span class="v-mode
 <details class="scripture-proofs" id="wsc-q17-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>p.</strong> Gen. 3:6, <strong>q.</strong> Gen. 2:16–17, <strong>r.</strong> Rom. 5:12–21; 1 Cor. 15:22, <strong>s.</strong> Gen. 3:16–19, 23</p></div>
+<p><strong>p.</strong> Gen. 3:6, <strong>q.</strong> Gen. 2:16-17, <strong>r.</strong> Rom. 5:12-21; 1 Cor. 15:22, <strong>s.</strong> Gen. 3:16-19, 23</p></div>
 </details>
 
 
@@ -209,7 +209,7 @@ Answer: The sinfulness of that <span class="v-const">estate whereinto</span><spa
 <details class="scripture-proofs" id="wsc-q18-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>t.</strong> Rom. 5:12, 19, <strong>u.</strong> Rom. 3:10; Col. 3:10; Eph. 4:24, <strong>w.</strong> Ps. 51:5; John 3:6; Rom. 3:18; Rom. 8:7–8; Eph. 2:3, <strong>x.</strong> Gen. 6:5; Ps. 53:1–3; Matt. 15:19; Rom. 3:10–18, 23</p></div>
+<p><strong>t.</strong> Rom. 5:12, 19, <strong>u.</strong> Rom. 3:10; Col. 3:10; Eph. 4:24, <strong>w.</strong> Ps. 51:5; John 3:6; Rom. 3:18; Rom. 8:7-8; Eph. 2:3, <strong>x.</strong> Gen. 6:5; Ps. 53:1-3; Matt. 15:19; Rom. 3:10-18, 23</p></div>
 </details>
 
 
@@ -220,7 +220,7 @@ Answer: All <span class="v-const">mankind</span><span class="v-modern">humanity<
 <details class="scripture-proofs" id="wsc-q19-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Gal. 3:10; Rev. 22:3, <strong>b.</strong> Gen. 3:16–19, <strong>y.</strong> Gen. 3:8, 24; John 8:34, 42, 44; Eph. 2:12; Eph. 4:18, <strong>z.</strong> John 3:36; Rom. 1:18; Eph. 2:3; Eph. 5:6</p></div>
+<p><strong>a.</strong> Gal. 3:10; Rev. 22:3, <strong>b.</strong> Gen. 3:16-19, <strong>y.</strong> Gen. 3:8, 24; John 8:34, 42, 44; Eph. 2:12; Eph. 4:18, <strong>z.</strong> John 3:36; Rom. 1:18; Eph. 2:3; Eph. 5:6</p></div>
 </details>
 
 
@@ -231,7 +231,7 @@ Answer: <span class="v-const">God, having</span><span class="v-modern">Having el
 <details class="scripture-proofs" id="wsc-q20-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>c.</strong> Ezek. 18:4; Rom. 5:12; Rom. 6:23, <strong>d.</strong> Matt. 25:41, 46; 2 Thess. 1:9; Rev. 14:9–11, <strong>e.</strong> Acts 13:48; Eph. 1:4–5; 2 Thess. 2:13–14</p></div>
+<p><strong>c.</strong> Ezek. 18:4; Rom. 5:12; Rom. 6:23, <strong>d.</strong> Matt. 25:41, 46; 2 Thess. 1:9; Rev. 14:9-11, <strong>e.</strong> Acts 13:48; Eph. 1:4-5; 2 Thess. 2:13-14</p></div>
 </details>
 
 
@@ -242,7 +242,7 @@ Answer: The only Redeemer of God's elect is the Lord Jesus Christ,<sup class="pr
 <details class="scripture-proofs" id="wsc-q21-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>f.</strong> Gen. 3:15; Gen. 17:7; Jer. 31:31–34; Matt. 20:28; 1 Cor. 11:25; Heb. 9:15, <strong>g.</strong> John 14:6; Acts 4:12; 1 Tim. 2:5–6, <strong>h.</strong> Ps. 2:7; Matt. 3:17; Matt. 17:5; John 1:18, <strong>i.</strong> Isa. 9:6</p></div>
+<p><strong>f.</strong> Gen. 3:15; Gen. 17:7; Jer. 31:31-34; Matt. 20:28; 1 Cor. 11:25; Heb. 9:15, <strong>g.</strong> John 14:6; Acts 4:12; 1 Tim. 2:5-6, <strong>h.</strong> Ps. 2:7; Matt. 3:17; Matt. 17:5; John 1:18, <strong>i.</strong> Isa. 9:6</p></div>
 </details>
 
 
@@ -276,7 +276,7 @@ Answer: Christ <span class="v-const">executeth</span><span class="v-modern">exec
 <details class="scripture-proofs" id="wsc-q24-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>p.</strong> Heb. 4:14–15; Heb. 5:5–6, <strong>q.</strong> Isa. 9:6–7; Luke 1:32–33; John 18:37; 1 Cor. 15:25, <strong>r.</strong> Luke 4:18–19, 21; Acts 1:1–2; Heb. 2:3, <strong>s.</strong> John 15:26–27</p></div>
+<p><strong>p.</strong> Heb. 4:14-15; Heb. 5:5-6, <strong>q.</strong> Isa. 9:6-7; Luke 1:32-33; John 18:37; 1 Cor. 15:25, <strong>r.</strong> Luke 4:18-19, 21; Acts 1:1-2; Heb. 2:3, <strong>s.</strong> John 15:26-27</p></div>
 </details>
 
 
@@ -287,7 +287,7 @@ Answer: Christ <span class="v-const">executeth</span><span class="v-modern">exec
 <details class="scripture-proofs" id="wsc-q25-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>t.</strong> John 4:41–42; John 20:30–31, <strong>u.</strong> Acts 8:32–35; Heb. 9:26–28; Heb. 10:12, <strong>w.</strong> Rom. 5:10–11; 2 Cor. 5:18; Col. 1:21–22</p></div>
+<p><strong>t.</strong> John 4:41-42; John 20:30-31, <strong>u.</strong> Acts 8:32-35; Heb. 9:26-28; Heb. 10:12, <strong>w.</strong> Rom. 5:10-11; 2 Cor. 5:18; Col. 1:21-22</p></div>
 </details>
 
 
@@ -310,7 +310,7 @@ Answer: Christ's humiliation consisted in his being born, and that in a low cond
 <details class="scripture-proofs" id="wsc-q27-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Luke 2:7; 2 Cor. 8:9; Gal. 4:4, <strong>x.</strong> Rom. 8:34; Heb. 7:25; Heb. 9:24, <strong>y.</strong> Ps. 110:3; Matt. 28:18–20; John 17:2; Col. 1:13, <strong>z.</strong> Ps. 2:6–9; Ps. 110:1–2; Matt. 12:28; 1 Cor. 15:24–26; Col. 2:15</p></div>
+<p><strong>a.</strong> Luke 2:7; 2 Cor. 8:9; Gal. 4:4, <strong>x.</strong> Rom. 8:34; Heb. 7:25; Heb. 9:24, <strong>y.</strong> Ps. 110:3; Matt. 28:18-20; John 17:2; Col. 1:13, <strong>z.</strong> Ps. 2:6-9; Ps. 110:1-2; Matt. 12:28; 1 Cor. 15:24-26; Col. 2:15</p></div>
 </details>
 
 
@@ -321,7 +321,7 @@ Answer: Christ's exaltation <span class="v-const">consisteth</span><span class="
 <details class="scripture-proofs" id="wsc-q28-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>b.</strong> Gal. 4:4, <strong>c.</strong> Isa. 53:3; Luke 9:58; John 4:6; John 11:35; Heb. 2:18, <strong>d.</strong> Ps. 22:1; Matt. 27:46; Isa. 53:10; 1 John 2:2, <strong>e.</strong> Gal. 3:13; Phil. 2:8, <strong>f.</strong> Matt. 12:40; 1 Cor. 15:3–4, <strong>g.</strong> 1 Cor. 15:4, <strong>h.</strong> Ps. 68:18; Acts 1:11; Eph. 4:8, <strong>i.</strong> Ps. 110:1; Acts 2:33–34</p></div>
+<p><strong>b.</strong> Gal. 4:4, <strong>c.</strong> Isa. 53:3; Luke 9:58; John 4:6; John 11:35; Heb. 2:18, <strong>d.</strong> Ps. 22:1; Matt. 27:46; Isa. 53:10; 1 John 2:2, <strong>e.</strong> Gal. 3:13; Phil. 2:8, <strong>f.</strong> Matt. 12:40; 1 Cor. 15:3-4, <strong>g.</strong> 1 Cor. 15:4, <strong>h.</strong> Ps. 68:18; Acts 1:11; Eph. 4:8, <strong>i.</strong> Ps. 110:1; Acts 2:33-34</p></div>
 </details>
 
 
@@ -356,7 +356,7 @@ Answer: Effectual calling is the work of God's Spirit, <span class="v-const">whe
 <details class="scripture-proofs" id="wsc-q31-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>m.</strong> Rom. 10:17; 1 Cor. 2:12–16; Eph. 2:8; Phil. 1:29, <strong>n.</strong> John 15:5; 1 Cor. 1:9; Eph. 3:17</p></div>
+<p><strong>m.</strong> Rom. 10:17; 1 Cor. 2:12-16; Eph. 2:8; Phil. 1:29, <strong>n.</strong> John 15:5; 1 Cor. 1:9; Eph. 3:17</p></div>
 </details>
 
 
@@ -367,7 +367,7 @@ Answer: <span class="v-const">They that</span><span class="v-modern">Those who</
 <details class="scripture-proofs" id="wsc-q32-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>o.</strong> Acts 26:18; 1 Cor. 2:10, 12; 2 Cor. 4:6; Eph. 1:17–18, <strong>p.</strong> Deut. 30:6; Ezek. 36:26–27; John 3:5, <strong>q.</strong> John 6:44–45; Acts 16:14, <strong>r.</strong> Isa. 45:22; Matt. 11:28–30; Rev. 22:17, <strong>s.</strong> Rom. 8:30</p></div>
+<p><strong>o.</strong> Acts 26:18; 1 Cor. 2:10, 12; 2 Cor. 4:6; Eph. 1:17-18, <strong>p.</strong> Deut. 30:6; Ezek. 36:26-27; John 3:5, <strong>q.</strong> John 6:44-45; Acts 16:14, <strong>r.</strong> Isa. 45:22; Matt. 11:28-30; Rev. 22:17, <strong>s.</strong> Rom. 8:30</p></div>
 </details>
 
 
@@ -390,7 +390,7 @@ Answer: Adoption is an act of God's free grace,<sup class="proof-marker">z</sup>
 <details class="scripture-proofs" id="wsc-q34-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> John 1:12; Rom. 8:17, <strong>t.</strong> Rom. 3:24, <strong>u.</strong> Rom. 4:6–8; 2 Cor. 5:19, <strong>w.</strong> 2 Cor. 5:21, <strong>x.</strong> Rom. 4:6, 11; Rom. 5:19, <strong>y.</strong> Gal. 2:16; Phil. 3:9, <strong>z.</strong> 1 John 3:1</p></div>
+<p><strong>a.</strong> John 1:12; Rom. 8:17, <strong>t.</strong> Rom. 3:24, <strong>u.</strong> Rom. 4:6-8; 2 Cor. 5:19, <strong>w.</strong> 2 Cor. 5:21, <strong>x.</strong> Rom. 4:6, 11; Rom. 5:19, <strong>y.</strong> Gal. 2:16; Phil. 3:9, <strong>z.</strong> 1 John 3:1</p></div>
 </details>
 
 
@@ -413,7 +413,7 @@ Answer: The benefits <span class="v-const">which</span><span class="v-modern">th
 <details class="scripture-proofs" id="wsc-q36-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>b.</strong> Ezek. 36:27; Phil. 2:13; 2 Thess. 2:13, <strong>c.</strong> 2 Cor. 5:17; Eph. 4:23–24; 1 Thess. 5:23, <strong>d.</strong> Ezek. 36:25–27; Rom. 6:4, 6, 12–14; 2 Cor. 7:1; 1 Pet. 2:24, <strong>e.</strong> Rom. 5:5, <strong>f.</strong> Rom. 5:1, <strong>g.</strong> Rom. 14:17</p></div>
+<p><strong>b.</strong> Ezek. 36:27; Phil. 2:13; 2 Thess. 2:13, <strong>c.</strong> 2 Cor. 5:17; Eph. 4:23-24; 1 Thess. 5:23, <strong>d.</strong> Ezek. 36:25-27; Rom. 6:4, 6, 12-14; 2 Cor. 7:1; 1 Pet. 2:24, <strong>e.</strong> Rom. 5:5, <strong>f.</strong> Rom. 5:1, <strong>g.</strong> Rom. 14:17</p></div>
 </details>
 
 
@@ -436,7 +436,7 @@ Answer: At the resurrection, believers, being raised up in glory,<sup class="pro
 <details class="scripture-proofs" id="wsc-q38-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>h.</strong> 2 Pet. 3:18, <strong>i.</strong> Phil. 1:6; 1 Pet. 1:5; Heb. 12:23, <strong>l.</strong> Luke 23:43; 2 Cor. 5:6, 8; Phil. 1:23, <strong>m.</strong> 1 Thess. 4:14, <strong>n.</strong> Dan. 12:2; John 5:28–29; Acts 24:15, <strong>o.</strong> 1 Cor. 15:42–43, <strong>p.</strong> Matt. 25:33–34, 46, <strong>q.</strong> Rom. 8:29</p></div>
+<p><strong>h.</strong> 2 Pet. 3:18, <strong>i.</strong> Phil. 1:6; 1 Pet. 1:5; Heb. 12:23, <strong>l.</strong> Luke 23:43; 2 Cor. 5:6, 8; Phil. 1:23, <strong>m.</strong> 1 Thess. 4:14, <strong>n.</strong> Dan. 12:2; John 5:28-29; Acts 24:15, <strong>o.</strong> 1 Cor. 15:42-43, <strong>p.</strong> Matt. 25:33-34, 46, <strong>q.</strong> Rom. 8:29</p></div>
 </details>
 
 
@@ -483,7 +483,7 @@ Answer: The sum of the ten commandments is, to love the Lord our God with all ou
 <details class="scripture-proofs" id="wsc-q42-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>r.</strong> Ps. 16:11; 1 Thess. 4:17, <strong>s.</strong> Deut. 29:29; Mic. 6:8; 1 John 5:2–3, <strong>t.</strong> Rom. 2:14–15; Rom. 10:5, <strong>u.</strong> Deut. 4:13; Matt. 19:17–19, <strong>w.</strong> Matt. 22:37–40</p></div>
+<p><strong>r.</strong> Ps. 16:11; 1 Thess. 4:17, <strong>s.</strong> Deut. 29:29; Mic. 6:8; 1 John 5:2-3, <strong>t.</strong> Rom. 2:14-15; Rom. 10:5, <strong>u.</strong> Deut. 4:13; Matt. 19:17-19, <strong>w.</strong> Matt. 22:37-40</p></div>
 </details>
 
 
@@ -530,7 +530,7 @@ Answer: The first commandment <span class="v-const">requireth</span><span class=
 <details class="scripture-proofs" id="wsc-q46-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> 1 Chron. 28:9; Isa. 45:20–25, <strong>x.</strong> Deut. 5:6, <strong>y.</strong> Luke 1:74–75; 1 Pet. 1:14–19, <strong>z.</strong> Deut. 5:7</p></div>
+<p><strong>a.</strong> 1 Chron. 28:9; Isa. 45:20-25, <strong>x.</strong> Deut. 5:6, <strong>y.</strong> Luke 1:74-75; 1 Pet. 1:14-19, <strong>z.</strong> Deut. 5:7</p></div>
 </details>
 
 
@@ -553,7 +553,7 @@ Answer: These <span class="v-const">words</span><span class="v-modern">words,</s
 <details class="scripture-proofs" id="wsc-q48-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>b.</strong> Ps. 14:1, <strong>c.</strong> Rom. 1:20–21, <strong>d.</strong> Ps. 81:10–11, <strong>e.</strong> Ezek. 8:16–18; Rom. 1:25, <strong>f.</strong> Deut. 30:17–18; Ps. 44:20–21; Ezek. 8:12</p></div>
+<p><strong>b.</strong> Ps. 14:1, <strong>c.</strong> Rom. 1:20-21, <strong>d.</strong> Ps. 81:10-11, <strong>e.</strong> Ezek. 8:16-18; Rom. 1:25, <strong>f.</strong> Deut. 30:17-18; Ps. 44:20-21; Ezek. 8:12</p></div>
 </details>
 
 
@@ -588,7 +588,7 @@ Answer: The second commandment <span class="v-const">forbiddeth the</span><span 
 <details class="scripture-proofs" id="wsc-q51-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>g.</strong> Deut. 5:8–10, <strong>h.</strong> Deut. 12:32; Matt. 28:20, <strong>i.</strong> Deut. 4:15–19; Rom. 1:22–23; Lev. 10:1–2</p></div>
+<p><strong>g.</strong> Deut. 5:8-10, <strong>h.</strong> Deut. 12:32; Matt. 28:20, <strong>i.</strong> Deut. 4:15-19; Rom. 1:22-23; Lev. 10:1-2</p></div>
 </details>
 
 
@@ -623,7 +623,7 @@ Answer: The third commandment <span class="v-const">requireth</span><span class=
 <details class="scripture-proofs" id="wsc-q54-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Ps. 95:2–3, 6–7; Ps. 96:9–10, <strong>m.</strong> Ps. 45:11; Isa. 54:5, <strong>n.</strong> 1 Cor. 10:22, <strong>o.</strong> Deut. 5:11</p></div>
+<p><strong>l.</strong> Ps. 95:2-3, 6-7; Ps. 96:9-10, <strong>m.</strong> Ps. 45:11; Isa. 54:5, <strong>n.</strong> 1 Cor. 10:22, <strong>o.</strong> Deut. 5:11</p></div>
 </details>
 
 
@@ -634,7 +634,7 @@ Answer: The third commandment <span class="v-const">forbiddeth</span><span class
 <details class="scripture-proofs" id="wsc-q55-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>p.</strong> Deut. 10:20; Ps. 29:2; Matt. 6:9, <strong>q.</strong> 1 Chron. 29:10–13; Rev. 15:3–4, <strong>r.</strong> Acts 2:42; 1 Cor. 11:27–28, <strong>s.</strong> Ps. 138:2; Rev. 22:18–19, <strong>t.</strong> Ps. 107:21–22; Rev. 4:11, <strong>u.</strong> Lev. 19:12; Matt. 5:33–37</p></div>
+<p><strong>p.</strong> Deut. 10:20; Ps. 29:2; Matt. 6:9, <strong>q.</strong> 1 Chron. 29:10-13; Rev. 15:3-4, <strong>r.</strong> Acts 2:42; 1 Cor. 11:27-28, <strong>s.</strong> Ps. 138:2; Rev. 22:18-19, <strong>t.</strong> Ps. 107:21-22; Rev. 4:11, <strong>u.</strong> Lev. 19:12; Matt. 5:33-37</p></div>
 </details>
 
 
@@ -669,7 +669,7 @@ Answer: The fourth commandment <span class="v-const">requireth the</span><span c
 <details class="scripture-proofs" id="wsc-q58-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>w.</strong> Deut. 28:58–59; 1 Sam. 3:13; 1 Sam. 4:11, <strong>x.</strong> Deut. 5:12–15</p></div>
+<p><strong>w.</strong> Deut. 28:58-59; 1 Sam. 3:13; 1 Sam. 4:11, <strong>x.</strong> Deut. 5:12-15</p></div>
 </details>
 
 
@@ -692,7 +692,7 @@ Answer: The <span class="v-const">sabbath</span><span class="v-modern">Sabbath</
 <details class="scripture-proofs" id="wsc-q60-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Mark 2:27–28; Acts 20:7; 1 Cor. 16:2; Rev. 1:10, <strong>b.</strong> Neh. 13:15–22; Isa. 58:13–14, <strong>z.</strong> Gen. 2:2–3</p></div>
+<p><strong>a.</strong> Mark 2:27-28; Acts 20:7; 1 Cor. 16:2; Rev. 1:10, <strong>b.</strong> Neh. 13:15-22; Isa. 58:13-14, <strong>z.</strong> Gen. 2:2-3</p></div>
 </details>
 
 
@@ -703,7 +703,7 @@ Answer: The fourth commandment <span class="v-const">forbiddeth</span><span clas
 <details class="scripture-proofs" id="wsc-q61-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>c.</strong> Lev. 23:3; Luke 4:16; Acts 20:7, <strong>d.</strong> Matt. 12:1–13, <strong>e.</strong> Neh. 13:15–22; Isa. 58:13–14; Amos 8:4–6</p></div>
+<p><strong>c.</strong> Lev. 23:3; Luke 4:16; Acts 20:7, <strong>d.</strong> Matt. 12:1-13, <strong>e.</strong> Neh. 13:15-22; Isa. 58:13-14; Amos 8:4-6</p></div>
 </details>
 
 
@@ -738,7 +738,7 @@ Answer: The fifth commandment <span class="v-const">requireth the</span><span cl
 <details class="scripture-proofs" id="wsc-q64-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>f.</strong> Lev. 23:3, <strong>g.</strong> Gen. 2:2–3, <strong>h.</strong> Deut. 5:16, <strong>i.</strong> Rom. 13:1, 7; Eph. 5:21–22, 24; Eph. 6:1, 4–5, 9; 1 Pet. 2:17</p></div>
+<p><strong>f.</strong> Lev. 23:3, <strong>g.</strong> Gen. 2:2-3, <strong>h.</strong> Deut. 5:16, <strong>i.</strong> Rom. 13:1, 7; Eph. 5:21-22, 24; Eph. 6:1, 4-5, 9; 1 Pet. 2:17</p></div>
 </details>
 
 
@@ -797,7 +797,7 @@ Answer: The sixth commandment <span class="v-const">forbiddeth the</span><span c
 <details class="scripture-proofs" id="wsc-q69-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> Deut. 5:16; Eph. 6:2–3, <strong>m.</strong> Deut. 5:17, <strong>n.</strong> Eph. 5:28–29, <strong>o.</strong> Gen. 9:6; Matt. 5:22; 1 John 3:15</p></div>
+<p><strong>l.</strong> Deut. 5:16; Eph. 6:2-3, <strong>m.</strong> Deut. 5:17, <strong>n.</strong> Eph. 5:28-29, <strong>o.</strong> Gen. 9:6; Matt. 5:22; 1 John 3:15</p></div>
 </details>
 
 
@@ -868,7 +868,7 @@ Answer: The eighth commandment <span class="v-const">forbiddeth whatsoever doth,
 <details class="scripture-proofs" id="wsc-q75-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>p.</strong> Deut. 5:18, <strong>q.</strong> 1 Cor. 7:2–3, 5; 1 Thess. 4:3–5, <strong>r.</strong> Matt. 5:28; Eph. 5:3–4, <strong>s.</strong> Deut. 5:19, <strong>t.</strong> Lev. 25:35; Eph. 4:28b; Phil. 2:4, <strong>u.</strong> Prov. 28:19f</p></div>
+<p><strong>p.</strong> Deut. 5:18, <strong>q.</strong> 1 Cor. 7:2-3, 5; 1 Thess. 4:3-5, <strong>r.</strong> Matt. 5:28; Eph. 5:3-4, <strong>s.</strong> Deut. 5:19, <strong>t.</strong> Lev. 25:35; Eph. 4:28b; Phil. 2:4, <strong>u.</strong> Prov. 28:19f</p></div>
 </details>
 
 
@@ -915,7 +915,7 @@ Answer: The tenth commandment is, <span class="v-const">Thou shalt</span><span c
 <details class="scripture-proofs" id="wsc-q79-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>w.</strong> Deut. 5:20, <strong>x.</strong> Zech. 8:16; Acts 25:10, <strong>y.</strong> Prov. 14:5, 25, <strong>z.</strong> Lev. 19:16; Ps. 15:3; Prov. 6:16–19; Luke 3:14</p></div>
+<p><strong>w.</strong> Deut. 5:20, <strong>x.</strong> Zech. 8:16; Acts 25:10, <strong>y.</strong> Prov. 14:5, 25, <strong>z.</strong> Lev. 19:16; Ps. 15:3; Prov. 6:16-19; Luke 3:14</p></div>
 </details>
 
 
@@ -938,7 +938,7 @@ Answer: The tenth commandment <span class="v-const">forbiddeth</span><span class
 <details class="scripture-proofs" id="wsc-q81-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Deut. 5:21, <strong>b.</strong> Ps. 34:1; Phil. 4:11; 1 Tim. 6:6; Heb. 13:5, <strong>c.</strong> Luke 15:6, 9, 11–32; Rom. 12:15; Phil. 2:4, <strong>d.</strong> 1 Cor. 10:10, <strong>e.</strong> Gal. 5:26</p></div>
+<p><strong>a.</strong> Deut. 5:21, <strong>b.</strong> Ps. 34:1; Phil. 4:11; 1 Tim. 6:6; Heb. 13:5, <strong>c.</strong> Luke 15:6, 9, 11-32; Rom. 12:15; Phil. 2:4, <strong>d.</strong> 1 Cor. 10:10, <strong>e.</strong> Gal. 5:26</p></div>
 </details>
 
 
@@ -973,7 +973,7 @@ Answer: Every sin <span class="v-const">deserveth</span><span class="v-modern">d
 <details class="scripture-proofs" id="wsc-q84-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>f.</strong> Gen. 8:21; Rom. 3:9f, <strong>g.</strong> Ezek. 8:6, 13, 15; Matt. 11:20–24; John 19:11, <strong>h.</strong> Matt. 25:41; Gal. 3:10; Eph. 5:6</p></div>
+<p><strong>f.</strong> Gen. 8:21; Rom. 3:9f, <strong>g.</strong> Ezek. 8:6, 13, 15; Matt. 11:20-24; John 19:11, <strong>h.</strong> Matt. 25:41; Gal. 3:10; Eph. 5:6</p></div>
 </details>
 
 
@@ -996,7 +996,7 @@ Answer: Faith in Jesus Christ is a saving grace,<sup class="proof-marker">l</sup
 <details class="scripture-proofs" id="wsc-q86-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>i.</strong> Mark 1:15; Acts 20:21; Acts 2:38; 1 Cor. 11:24–25; Col. 3:16, <strong>l.</strong> Eph. 2:8–9; Rom. 4:16, <strong>m.</strong> John 20:30–31; Gal. 2:15–16; Phil. 3:3–11</p></div>
+<p><strong>i.</strong> Mark 1:15; Acts 20:21; Acts 2:38; 1 Cor. 11:24-25; Col. 3:16, <strong>l.</strong> Eph. 2:8-9; Rom. 4:16, <strong>m.</strong> John 20:30-31; Gal. 2:15-16; Phil. 3:3-11</p></div>
 </details>
 
 
@@ -1007,7 +1007,7 @@ Answer: Repentance unto life is a saving grace,<sup class="proof-marker">n</sup>
 <details class="scripture-proofs" id="wsc-q87-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>n.</strong> Acts 11:18; 2 Tim. 2:25, <strong>o.</strong> Ps. 51:1–4; Joel 2:13; Luke 15:7, 10; Acts 2:37, <strong>p.</strong> Jer. 31:18–19; Luke 1:16–17; 1 Thess. 1:9, <strong>q.</strong> 2 Chron. 7:14; Ps. 119:57–64; Matt. 3:8; 2 Cor. 7:10</p></div>
+<p><strong>n.</strong> Acts 11:18; 2 Tim. 2:25, <strong>o.</strong> Ps. 51:1-4; Joel 2:13; Luke 15:7, 10; Acts 2:37, <strong>p.</strong> Jer. 31:18-19; Luke 1:16-17; 1 Thess. 1:9, <strong>q.</strong> 2 Chron. 7:14; Ps. 119:57-64; Matt. 3:8; 2 Cor. 7:10</p></div>
 </details>
 
 
@@ -1042,7 +1042,7 @@ Answer: That the Word may become effectual to salvation, we must attend <span cl
 <details class="scripture-proofs" id="wsc-q90-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>r.</strong> Matt. 28:18–20; Acts 2:41–42, <strong>s.</strong> Neh. 8:8–9; Acts 20:32; Rom. 10:14–17; 2 Tim. 3:15–17</p></div>
+<p><strong>r.</strong> Matt. 28:18-20; Acts 2:41-42, <strong>s.</strong> Neh. 8:8-9; Acts 20:32; Rom. 10:14-17; 2 Tim. 3:15-17</p></div>
 </details>
 
 
@@ -1065,7 +1065,7 @@ Answer: A sacrament is a holy ordinance instituted by Christ;<sup class="proof-m
 <details class="scripture-proofs" id="wsc-q92-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>t.</strong> Deut. 6:16f; Ps. 119:18; 1 Pet. 2:1–2, <strong>u.</strong> Ps. 119:11; 2 Thess. 2:10; Heb. 4:2, <strong>w.</strong> 1 Cor. 3:7; 1 Cor. 1:12–17, <strong>x.</strong> Matt. 28:19; Matt. 26:26–28; Mark 14:22–25</p></div>
+<p><strong>t.</strong> Deut. 6:16f; Ps. 119:18; 1 Pet. 2:1-2, <strong>u.</strong> Ps. 119:11; 2 Thess. 2:10; Heb. 4:2, <strong>w.</strong> 1 Cor. 3:7; 1 Cor. 1:12-17, <strong>x.</strong> Matt. 28:19; Matt. 26:26-28; Mark 14:22-25</p></div>
 </details>
 
 
@@ -1088,7 +1088,7 @@ Answer: Baptism is a sacrament, <span class="v-const">wherein</span><span class=
 <details class="scripture-proofs" id="wsc-q94-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> 1 Cor. 11:23–26, <strong>b.</strong> Matt. 28:19, <strong>c.</strong> Acts 2:38–42, <strong>y.</strong> Gal. 3:27; 1 Cor. 10:16–17, <strong>z.</strong> Matt. 28:19</p></div>
+<p><strong>a.</strong> 1 Cor. 11:23-26, <strong>b.</strong> Matt. 28:19, <strong>c.</strong> Acts 2:38-42, <strong>y.</strong> Gal. 3:27; 1 Cor. 10:16-17, <strong>z.</strong> Matt. 28:19</p></div>
 </details>
 
 
@@ -1099,7 +1099,7 @@ Answer: Baptism is not to be administered to any that are out of the visible chu
 <details class="scripture-proofs" id="wsc-q95-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>d.</strong> Acts 2:41; Acts 8:12, 36, 38; Acts 18:8, <strong>e.</strong> Gen. 17:7, 9–11; Acts 2:38–39; Acts 16:32–33; Col. 2:11–12</p></div>
+<p><strong>d.</strong> Acts 2:41; Acts 8:12, 36, 38; Acts 18:8, <strong>e.</strong> Gen. 17:7, 9-11; Acts 2:38-39; Acts 16:32-33; Col. 2:11-12</p></div>
 </details>
 
 
@@ -1134,7 +1134,7 @@ Answer: Prayer is an offering up of our desires <span class="v-const">unto</span
 <details class="scripture-proofs" id="wsc-q98-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>f.</strong> Luke 22:19–20; 1 Cor. 11:23–26, <strong>g.</strong> 1 Cor. 10:16–17, <strong>h.</strong> 1 Cor. 11:27–32, <strong>i.</strong> Ps. 10:17; Ps. 62:8; Matt. 7:7–8</p></div>
+<p><strong>f.</strong> Luke 22:19-20; 1 Cor. 11:23-26, <strong>g.</strong> 1 Cor. 10:16-17, <strong>h.</strong> 1 Cor. 11:27-32, <strong>i.</strong> Ps. 10:17; Ps. 62:8; Matt. 7:7-8</p></div>
 </details>
 
 
@@ -1145,7 +1145,7 @@ Answer: The whole Word of God is of use to direct us in prayer;<sup class="proof
 <details class="scripture-proofs" id="wsc-q99-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>l.</strong> John 16:23–24, <strong>m.</strong> Ps. 32:5–6; Dan. 9:4–19; 1 John 1:9, <strong>n.</strong> Ps. 103:1–5; Phil. 4:6, <strong>o.</strong> 1 John 5:14</p></div>
+<p><strong>l.</strong> John 16:23-24, <strong>m.</strong> Ps. 32:5-6; Dan. 9:4-19; 1 John 1:9, <strong>n.</strong> Ps. 103:1-5; Phil. 4:6, <strong>o.</strong> 1 John 5:14</p></div>
 </details>
 
 
@@ -1168,7 +1168,7 @@ Answer: In the first petition, which is, Hallowed be <span class="v-const">thy</
 <details class="scripture-proofs" id="wsc-q101-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>p.</strong> Matt. 6:9–13, <strong>q.</strong> Ps. 95:6, <strong>r.</strong> Eph. 3:12, <strong>s.</strong> Matt. 7:9–11; Luke 11:11–13; Rom. 8:15, <strong>t.</strong> Eph. 3:20, <strong>u.</strong> Eph. 6:18; 1 Tim. 2:1–2, <strong>w.</strong> Ps. 67:1–3; Ps. 99:3; Ps. 100:3–4</p></div>
+<p><strong>p.</strong> Matt. 6:9-13, <strong>q.</strong> Ps. 95:6, <strong>r.</strong> Eph. 3:12, <strong>s.</strong> Matt. 7:9-11; Luke 11:11-13; Rom. 8:15, <strong>t.</strong> Eph. 3:20, <strong>u.</strong> Eph. 6:18; 1 Tim. 2:1-2, <strong>w.</strong> Ps. 67:1-3; Ps. 99:3; Ps. 100:3-4</p></div>
 </details>
 
 
@@ -1179,7 +1179,7 @@ Answer: In the second petition, which is, <span class="v-const">Thy</span><span 
 <details class="scripture-proofs" id="wsc-q102-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>a.</strong> Ps. 119:5; Luke 22:32; 2 Thess. 3:1–5, <strong>b.</strong> Rev. 22:20, <strong>x.</strong> Rom. 11:33–36; Rev. 4:11, <strong>y.</strong> Matt. 12:25–28; Rom. 16:20; 1 John 3:8, <strong>z.</strong> Ps. 72:8–11; Matt. 24:14; 1 Cor. 15:24–25</p></div>
+<p><strong>a.</strong> Ps. 119:5; Luke 22:32; 2 Thess. 3:1-5, <strong>b.</strong> Rev. 22:20, <strong>x.</strong> Rom. 11:33-36; Rev. 4:11, <strong>y.</strong> Matt. 12:25-28; Rom. 16:20; 1 John 3:8, <strong>z.</strong> Ps. 72:8-11; Matt. 24:14; 1 Cor. 15:24-25</p></div>
 </details>
 
 
@@ -1202,7 +1202,7 @@ Answer: In the fourth petition, which is, Give us this day our daily bread, we p
 <details class="scripture-proofs" id="wsc-q104-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>c.</strong> Ps. 19:14; 1 Thess. 5:23; Heb. 13:20–21, <strong>d.</strong> Ps. 103:20–21; Heb. 1:14, <strong>e.</strong> Prov. 30:8–9; Matt. 6:31–34; Phil. 4:11, 19; 1 Tim. 6:6–8</p></div>
+<p><strong>c.</strong> Ps. 19:14; 1 Thess. 5:23; Heb. 13:20-21, <strong>d.</strong> Ps. 103:20-21; Heb. 1:14, <strong>e.</strong> Prov. 30:8-9; Matt. 6:31-34; Phil. 4:11, 19; 1 Tim. 6:6-8</p></div>
 </details>
 
 
@@ -1225,7 +1225,7 @@ Answer: In the sixth petition, which is, And lead us not into temptation, but de
 <details class="scripture-proofs" id="wsc-q106-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>f.</strong> Ps. 51:1–2, 7, 9; Dan. 9:17–19; 1 John 1:7, <strong>g.</strong> Matt. 18:21–35; Eph. 4:32; Col. 3:13, <strong>h.</strong> Ps. 19:13; Matt. 26:41; John 17:15</p></div>
+<p><strong>f.</strong> Ps. 51:1-2, 7, 9; Dan. 9:17-19; 1 John 1:7, <strong>g.</strong> Matt. 18:21-35; Eph. 4:32; Col. 3:13, <strong>h.</strong> Ps. 19:13; Matt. 26:41; John 17:15</p></div>
 </details>
 
 
@@ -1236,7 +1236,7 @@ Answer: The conclusion of the Lord's Prayer, which is, For <span class="v-const"
 <details class="scripture-proofs" id="wsc-q107-proofs">
 <summary>Scripture Proofs</summary>
 <div class="proofs-body">
-<p><strong>i.</strong> Luke 22:31–32; 1 Cor. 10:13; 2 Cor. 12:7–9; Heb. 2:18; Dan. 9:4, 7–9, 16–19; Luke 18:1, 7–8, <strong>l.</strong> 1 Chron. 29:10–13, <strong>m.</strong> 1 Cor. 14:16; Rev. 22:20</p></div>
+<p><strong>i.</strong> Luke 22:31-32; 1 Cor. 10:13; 2 Cor. 12:7-9; Heb. 2:18; Dan. 9:4, 7-9, 16-19; Luke 18:1, 7-8, <strong>l.</strong> 1 Chron. 29:10-13, <strong>m.</strong> 1 Cor. 14:16; Rev. 22:20</p></div>
 </details>
 
 

--- a/_pages/wsc.md
+++ b/_pages/wsc.md
@@ -18,7 +18,7 @@ Answer: Man's chief end is to glorify God,<sup class="proof-marker">a</sup> and 
 
 
 <span id="wsc-q2"></span>
-### Question 2: What rule <span class="v-const">hath</span><span class="v-modern">has</span> God given to direct us how we may glorify and enjoy him?  
+### Question 2: What rule hath God given to direct us how we may glorify and enjoy him?  
 Answer: The Word of God, which is contained in the Scriptures of the Old and New Testaments,<sup class="proof-marker">c</sup> is the only rule to direct us how we may glorify and enjoy him.<sup class="proof-marker">d</sup>
 
 <details class="scripture-proofs" id="wsc-q2-proofs">
@@ -87,7 +87,7 @@ Answer: The decrees of God are, his eternal purpose, according to the counsel of
 
 
 <span id="wsc-q8"></span>
-### Question 8: How <span class="v-const">doth</span><span class="v-modern">does</span> God execute his decrees?  
+### Question 8: How doth God execute his decrees?  
 Answer: God <span class="v-const">executeth</span><span class="v-modern">executes</span> his decrees in the works of creation and providence.<sup class="proof-marker">y</sup>
 
 <details class="scripture-proofs" id="wsc-q8-proofs">
@@ -133,7 +133,7 @@ Answer: God's works of providence are, his most holy,<sup class="proof-marker">f
 
 
 <span id="wsc-q12"></span>
-### Question 12: What special act of providence did God exercise towards man in the <span class="v-const">estate wherein</span><span class="v-modern">state in which</span> he was created?  
+### Question 12: What special act of providence did God exercise towards man in the estate wherein he was created?  
 Answer: When God had created man, he entered into a covenant of life with him, upon condition of perfect obedience; forbidding him to eat of the tree of the knowledge of good and evil, upon pain of death.<sup class="proof-marker">m</sup>
 
 <details class="scripture-proofs" id="wsc-q12-proofs">
@@ -145,7 +145,7 @@ Answer: When God had created man, he entered into a covenant of life with him, u
 
 
 <span id="wsc-q13"></span>
-### Question 13: Did our first parents continue in the <span class="v-const">estate wherein</span><span class="v-modern">state in which</span> they were created?  
+### Question 13: Did our first parents continue in the estate wherein they were created?  
 Answer: Our first parents, being left to the freedom of their own will, fell from the <span class="v-const">estate wherein</span><span class="v-modern">state in which</span> they were created, by sinning against God.<sup class="proof-marker">n</sup>
 
 <details class="scripture-proofs" id="wsc-q13-proofs">
@@ -168,7 +168,7 @@ Answer: Sin is any <span class="v-const">want</span><span class="v-modern">lack<
 
 
 <span id="wsc-q15"></span>
-### Question 15: What was the sin <span class="v-const">whereby</span><span class="v-modern">by which</span> our first parents fell from the <span class="v-const">estate wherein</span><span class="v-modern">state in which</span> they were created?  
+### Question 15: What was the sin whereby our first parents fell from the estate wherein they were created?  
 Answer: The sin <span class="v-const">whereby</span><span class="v-modern">by which</span> our first parents fell from the <span class="v-const">estate wherein</span><span class="v-modern">state in which</span> they were created, was their eating the forbidden fruit.<sup class="proof-marker">p</sup>
 
 <details class="scripture-proofs" id="wsc-q15-proofs">
@@ -180,7 +180,7 @@ Answer: The sin <span class="v-const">whereby</span><span class="v-modern">by wh
 
 
 <span id="wsc-q16"></span>
-### Question 16: Did all <span class="v-const">mankind</span><span class="v-modern">humanity</span> fall in Adam's first <span class="v-const">transgression.?</span><span class="v-modern">transgression?</span>  
+### Question 16: Did all mankind fall in Adam's first transgression.?  
 Answer: The covenant being made with Adam,<sup class="proof-marker">q</sup> not only for himself, but for his posterity; all <span class="v-const">mankind,</span><span class="v-modern">humanity,</span> descending from him by ordinary generation, sinned in him, and fell with him, in his first transgression.<sup class="proof-marker">r</sup>
 
 <details class="scripture-proofs" id="wsc-q16-proofs">
@@ -192,7 +192,7 @@ Answer: The covenant being made with Adam,<sup class="proof-marker">q</sup> not 
 
 
 <span id="wsc-q17"></span>
-### Question 17: Into what <span class="v-const">estate</span><span class="v-modern">state</span> did the fall bring <span class="v-const">mankind?</span><span class="v-modern">humanity?</span>  
+### Question 17: Into what estate did the fall bring mankind?  
 Answer: The fall brought <span class="v-const">mankind</span><span class="v-modern">humanity</span> into <span class="v-const">an estate</span><span class="v-modern">a state</span> of sin and misery.<sup class="proof-marker">s</sup>
 
 <details class="scripture-proofs" id="wsc-q17-proofs">
@@ -203,7 +203,7 @@ Answer: The fall brought <span class="v-const">mankind</span><span class="v-mode
 
 
 <span id="wsc-q18"></span>
-### Question 18: <span class="v-const">Wherein consists</span><span class="v-modern">What is</span> the sinfulness of that <span class="v-const">estate whereinto</span><span class="v-modern">state into which</span> man fell?  
+### Question 18: Wherein consists the sinfulness of that estate whereinto man fell?  
 Answer: The sinfulness of that <span class="v-const">estate whereinto</span><span class="v-modern">state into which</span> man fell, consists in the guilt of Adam's first sin,<sup class="proof-marker">t</sup> the <span class="v-const">want</span><span class="v-modern">lack</span> of original righteousness,<sup class="proof-marker">u</sup> and the corruption of his whole nature,<sup class="proof-marker">w</sup> which is commonly called original sin; together with all actual transgressions <span class="v-const">which</span><span class="v-modern">that</span> proceed from it.<sup class="proof-marker">x</sup>
 
 <details class="scripture-proofs" id="wsc-q18-proofs">
@@ -214,7 +214,7 @@ Answer: The sinfulness of that <span class="v-const">estate whereinto</span><spa
 
 
 <span id="wsc-q19"></span>
-### Question 19: What is the misery of that <span class="v-const">estate whereinto</span><span class="v-modern">state into which</span> man fell?  
+### Question 19: What is the misery of that estate whereinto man fell?  
 Answer: All <span class="v-const">mankind</span><span class="v-modern">humanity</span> by their fall lost communion with God,<sup class="proof-marker">y</sup> are under his wrath and curse,<sup class="proof-marker">a</sup> and so made liable to all the miseries of this life,<sup class="proof-marker">b</sup> to death itself, and to the pains of hell forever.<sup class="proof-marker">d</sup>
 
 <details class="scripture-proofs" id="wsc-q19-proofs">
@@ -225,7 +225,7 @@ Answer: All <span class="v-const">mankind</span><span class="v-modern">humanity<
 
 
 <span id="wsc-q20"></span>
-### Question 20: Did God leave all <span class="v-const">mankind</span><span class="v-modern">humanity</span> to perish in the <span class="v-const">estate</span><span class="v-modern">state</span> of sin and misery?  
+### Question 20: Did God leave all mankind to perish in the estate of sin and misery?  
 Answer: <span class="v-const">God, having</span><span class="v-modern">Having elected some to everlasting life,</span> out of his mere good pleasure, from all eternity, elected some to everlasting life,<sup class="proof-marker">e</sup> did enter into a covenant of grace to deliver them out of the <span class="v-const">estate</span><span class="v-modern">state</span> of sin and misery, and to bring them into <span class="v-const">an estate</span><span class="v-modern">a state</span> of salvation by a Redeemer.<sup class="proof-marker">f</sup>
 
 <details class="scripture-proofs" id="wsc-q20-proofs">
@@ -259,7 +259,7 @@ Answer: Christ, the Son of God, became man, by taking to himself a true body, an
 
 
 <span id="wsc-q23"></span>
-### Question 23: What offices <span class="v-const">doth</span><span class="v-modern">does</span> Christ execute as our <span class="v-const">Redeemer.?</span><span class="v-modern">Redeemer?</span>  
+### Question 23: What offices doth Christ execute as our Redeemer.?  
 Answer: Christ, as our Redeemer, <span class="v-const">executeth</span><span class="v-modern">executes</span> the offices of a prophet,<sup class="proof-marker">o</sup> of a priest,<sup class="proof-marker">p</sup> and of a king,<sup class="proof-marker">q</sup> both in his <span class="v-const">estate</span><span class="v-modern">state</span> of humiliation and exaltation.
 
 <details class="scripture-proofs" id="wsc-q23-proofs">
@@ -270,7 +270,7 @@ Answer: Christ, as our Redeemer, <span class="v-const">executeth</span><span cla
 
 
 <span id="wsc-q24"></span>
-### Question 24: How <span class="v-const">doth</span><span class="v-modern">does</span> Christ execute the office of a prophet?  
+### Question 24: How doth Christ execute the office of a prophet?  
 Answer: Christ <span class="v-const">executeth</span><span class="v-modern">executes</span> the office of a prophet, in revealing to us, by his Word and Spirit,<sup class="proof-marker">s</sup> the will of God for our salvation.<sup class="proof-marker">t</sup>
 
 <details class="scripture-proofs" id="wsc-q24-proofs">
@@ -281,7 +281,7 @@ Answer: Christ <span class="v-const">executeth</span><span class="v-modern">exec
 
 
 <span id="wsc-q25"></span>
-### Question 25: How <span class="v-const">doth</span><span class="v-modern">does</span> Christ execute the office of a priest?  
+### Question 25: How doth Christ execute the office of a priest?  
 Answer: Christ <span class="v-const">executeth</span><span class="v-modern">executes</span> the office of a priest, in his once offering <span class="v-modern">himself</span> up <span class="v-const">of himself</span><span class="v-modern">as</span> a sacrifice to satisfy divine justice,<sup class="proof-marker">u</sup> and reconcile us to God,<sup class="proof-marker">w</sup> and in making continual intercession for us.<sup class="proof-marker">x</sup>
 
 <details class="scripture-proofs" id="wsc-q25-proofs">
@@ -292,7 +292,7 @@ Answer: Christ <span class="v-const">executeth</span><span class="v-modern">exec
 
 
 <span id="wsc-q26"></span>
-### Question 26: How <span class="v-const">doth</span><span class="v-modern">does</span> Christ execute the office of a king?  
+### Question 26: How doth Christ execute the office of a king?  
 Answer: Christ <span class="v-const">executeth</span><span class="v-modern">executes</span> the office of a king, in subduing us to himself, in ruling and defending us,<sup class="proof-marker">y</sup> and in restraining and conquering all his and our enemies.<sup class="proof-marker">z</sup>
 
 <details class="scripture-proofs" id="wsc-q26-proofs">
@@ -304,7 +304,7 @@ Answer: Christ <span class="v-const">executeth</span><span class="v-modern">exec
 
 
 <span id="wsc-q27"></span>
-### Question 27: <span class="v-const">Wherein did</span><span class="v-modern">What was</span> Christ's <span class="v-const">humiliation consist?</span><span class="v-modern">state of humiliation?</span>  
+### Question 27: Wherein did Christ's humiliation consist?  
 Answer: Christ's humiliation consisted in his being born, and that in a low condition,<sup class="proof-marker">a</sup> made under the law,<sup class="proof-marker">b</sup> undergoing the miseries of this life, the wrath of God,<sup class="proof-marker">d</sup> and the cursed death of the cross;<sup class="proof-marker">e</sup> in being buried, and continuing under the power of death for a time.<sup class="proof-marker">f</sup>
 
 <details class="scripture-proofs" id="wsc-q27-proofs">
@@ -315,7 +315,7 @@ Answer: Christ's humiliation consisted in his being born, and that in a low cond
 
 
 <span id="wsc-q28"></span>
-### Question 28: <span class="v-const">Wherein consisteth</span><span class="v-modern">What is</span> Christ's <span class="v-modern">state of</span> exaltation?  
+### Question 28: Wherein consisteth Christ's exaltation?  
 Answer: Christ's exaltation <span class="v-const">consisteth</span><span class="v-modern">consists</span> in his rising <span class="v-const">again</span> from the dead on the third day,<sup class="proof-marker">g</sup> in ascending <span class="v-const">up</span> into heaven,<sup class="proof-marker">h</sup> in sitting at the right hand of God the Father,<sup class="proof-marker">i</sup> and in coming to judge the world at the last day.
 
 <details class="scripture-proofs" id="wsc-q28-proofs">
@@ -338,7 +338,7 @@ Answer: We are made partakers of the redemption purchased by Christ, by the effe
 
 
 <span id="wsc-q30"></span>
-### Question 30: How <span class="v-const">doth</span><span class="v-modern">does</span> the Spirit apply to us the redemption purchased by Christ?  
+### Question 30: How doth the Spirit apply to us the redemption purchased by Christ?  
 Answer: The Spirit <span class="v-const">applieth</span><span class="v-modern">applies</span> to us the redemption purchased by Christ, by working faith in us,<sup class="proof-marker">m</sup> and <span class="v-const">thereby</span><span class="v-modern">by this</span> uniting us to Christ in our effectual calling.<sup class="proof-marker">n</sup>
 
 <details class="scripture-proofs" id="wsc-q30-proofs">
@@ -361,7 +361,7 @@ Answer: Effectual calling is the work of God's Spirit, <span class="v-const">whe
 
 
 <span id="wsc-q32"></span>
-### Question 32: What benefits do <span class="v-const">they that</span><span class="v-modern">those who</span> are effectually called partake of in this life?  
+### Question 32: What benefits do they that are effectually called partake of in this life?  
 Answer: <span class="v-const">They that</span><span class="v-modern">Those who</span> are effectually called <span class="v-const">do</span><span class="v-modern">partake</span> in this life <span class="v-const">partake</span> of justification, adoption, and sanctification, and the several benefits <span class="v-const">which</span><span class="v-modern">that</span> in this life <span class="v-const">do</span> either accompany or flow from them.<sup class="proof-marker">s</sup>
 
 <details class="scripture-proofs" id="wsc-q32-proofs">
@@ -407,7 +407,7 @@ Answer: Sanctification is the work of God's free grace,<sup class="proof-marker"
 
 
 <span id="wsc-q36"></span>
-### Question 36: What are the benefits <span class="v-const">which</span><span class="v-modern">that</span> in this life <span class="v-const">do</span> accompany or flow from justification, adoption, and sanctification?  
+### Question 36: What are the benefits which in this life do accompany or flow from justification, adoption, and sanctification?  
 Answer: The benefits <span class="v-const">which</span><span class="v-modern">that</span> in this life <span class="v-const">do</span> accompany or flow from justification, adoption, and sanctification, are, assurance of God's love, peace of conscience,<sup class="proof-marker">f</sup> joy in the Holy <span class="v-const">Ghost,</span><span class="v-modern">Spirit,</span><sup class="proof-marker">g</sup> increase of grace,<sup class="proof-marker">h</sup> and perseverance <span class="v-const">therein</span><span class="v-modern">in it</span> to the end.<sup class="proof-marker">i</sup>
 
 <details class="scripture-proofs" id="wsc-q36-proofs">
@@ -441,7 +441,7 @@ Answer: At the resurrection, believers, being raised up in glory,<sup class="pro
 
 
 <span id="wsc-q39"></span>
-### Question 39: What is the duty <span class="v-const">which</span><span class="v-modern">that</span> God <span class="v-const">requireth</span><span class="v-modern">requires</span> of man?  
+### Question 39: What is the duty which God requireth of man?  
 Answer: The duty <span class="v-const">which</span><span class="v-modern">that</span> God <span class="v-const">requireth</span><span class="v-modern">requires</span> of man, is obedience to his revealed will.<sup class="proof-marker">s</sup>
 
 <details class="scripture-proofs" id="wsc-q39-proofs">
@@ -465,7 +465,7 @@ Answer: The rule <span class="v-const">which</span><span class="v-modern">that</
 
 
 <span id="wsc-q41"></span>
-### Question 41: <span class="v-const">Wherein</span><span class="v-modern">Where</span> is the moral law <span class="v-const">summarily comprehended?</span><span class="v-modern">summarized?</span>  
+### Question 41: Wherein is the moral law summarily comprehended?  
 Answer: The moral law is <span class="v-const">summarily comprehended</span><span class="v-modern">summarized</span> in the <span class="v-const">ten commandments.</span><span class="v-modern">Ten Commandments.</span><sup class="proof-marker">u</sup>
 
 <details class="scripture-proofs" id="wsc-q41-proofs">
@@ -500,7 +500,7 @@ Answer: The preface to the <span class="v-const">ten commandments</span><span cl
 
 
 <span id="wsc-q44"></span>
-### Question 44: What <span class="v-const">doth</span><span class="v-modern">does</span> the preface to the <span class="v-const">ten commandments</span><span class="v-modern">Ten Commandments</span> teach us?  
+### Question 44: What doth the preface to the ten commandments teach us?  
 Answer: The preface to the <span class="v-const">ten commandments teacheth us,</span><span class="v-modern">Ten Commandments teaches us</span> that because God is the Lord, and our God, and Redeemer, therefore we are bound to keep all his commandments.<sup class="proof-marker">y</sup>
 
 <details class="scripture-proofs" id="wsc-q44-proofs">
@@ -674,7 +674,7 @@ Answer: The fourth commandment <span class="v-const">requireth the</span><span c
 
 
 <span id="wsc-q59"></span>
-### Question 59: Which day of the seven <span class="v-const">hath</span><span class="v-modern">has</span> God appointed to be the weekly <span class="v-const">sabbath?</span><span class="v-modern">Sabbath?</span>  
+### Question 59: Which day of the seven hath God appointed to be the weekly sabbath?  
 Answer: From the beginning of the world to the resurrection of Christ, God appointed the seventh day of the week to be the weekly sabbath;<sup class="proof-marker">z</sup> and the first day of the week ever since, to continue to the end of the world, which is the Christian sabbath.<sup class="proof-marker">a</sup>
 
 <details class="scripture-proofs" id="wsc-q59-proofs">
@@ -943,7 +943,7 @@ Answer: The tenth commandment <span class="v-const">forbiddeth</span><span class
 
 
 <span id="wsc-q82"></span>
-### Question 82: Is any man able <span class="v-const">perfectly</span> to keep the commandments of <span class="v-const">God?</span><span class="v-modern">God perfectly?</span>  
+### Question 82: Is any man able perfectly to keep the commandments of God?  
 Answer: No mere <span class="v-const">men,</span><span class="v-modern">man</span> since the fall, is able in this life <span class="v-const">perfectly</span> to keep the commandments of <span class="v-const">God,</span><span class="v-modern">God perfectly,</span> but <span class="v-const">doth</span> daily <span class="v-const">break</span><span class="v-modern">breaks</span> them in thought, word, and deed.<sup class="proof-marker">f</sup>
 
 <details class="scripture-proofs" id="wsc-q82-proofs">
@@ -967,7 +967,7 @@ Answer: Some sins in themselves, and by reason of several aggravations, are more
 
 
 <span id="wsc-q84"></span>
-### Question 84: What <span class="v-const">doth</span><span class="v-modern">does</span> every sin deserve?  
+### Question 84: What doth every sin deserve?  
 Answer: Every sin <span class="v-const">deserveth</span><span class="v-modern">deserves</span> God's wrath and curse, both in this life, and that which is to come.<sup class="proof-marker">h</sup>
 
 <details class="scripture-proofs" id="wsc-q84-proofs">
@@ -978,7 +978,7 @@ Answer: Every sin <span class="v-const">deserveth</span><span class="v-modern">d
 
 
 <span id="wsc-q85"></span>
-### Question 85: What <span class="v-const">doth</span><span class="v-modern">does</span> God require of us, that we may escape his wrath and curse, due to us for sin?  
+### Question 85: What doth God require of us, that we may escape his wrath and curse, due to us for sin?  
 Answer: To escape the wrath and curse of God, due to us for sin, God <span class="v-const">requireth</span><span class="v-modern">requires</span> of us faith in Jesus <span class="v-const">Christ,</span><span class="v-modern">Christ and</span> repentance unto life,<sup class="proof-marker">i</sup> with the diligent use of all the outward means <span class="v-const">whereby</span><span class="v-modern">by which</span> Christ <span class="v-const">communicateth</span><span class="v-modern">communicates</span> to us the benefits of redemption.
 
 <details class="scripture-proofs" id="wsc-q85-proofs">
@@ -1012,7 +1012,7 @@ Answer: Repentance unto life is a saving grace,<sup class="proof-marker">n</sup>
 
 
 <span id="wsc-q88"></span>
-### Question 88: What are the outward and ordinary means <span class="v-const">whereby</span><span class="v-modern">by which</span> Christ <span class="v-const">communicateth</span><span class="v-modern">communicates</span> to us the benefits of redemption?  
+### Question 88: What are the outward and ordinary means whereby Christ communicateth to us the benefits of redemption?  
 Answer: The outward and ordinary means <span class="v-const">whereby</span><span class="v-modern">by which</span> Christ <span class="v-const">communicateth</span><span class="v-modern">communicates</span> to us the benefits of redemption are, his ordinances, especially the <span class="v-const">Word,</span><span class="v-modern">word,</span> sacraments, and prayer; all <span class="v-modern">of</span> which are made effectual to the elect for salvation.<sup class="proof-marker">r</sup>
 
 <details class="scripture-proofs" id="wsc-q88-proofs">
@@ -1139,7 +1139,7 @@ Answer: Prayer is an offering up of our desires <span class="v-const">unto</span
 
 
 <span id="wsc-q99"></span>
-### Question 99: What rule <span class="v-const">hath</span><span class="v-modern">has</span> God given for our direction in prayer?  
+### Question 99: What rule hath God given for our direction in prayer?  
 Answer: The whole Word of God is of use to direct us in prayer;<sup class="proof-marker">o</sup> but the special rule of direction is that form of prayer which Christ taught his disciples, commonly called the Lord's Prayer.
 
 <details class="scripture-proofs" id="wsc-q99-proofs">
@@ -1150,7 +1150,7 @@ Answer: The whole Word of God is of use to direct us in prayer;<sup class="proof
 
 
 <span id="wsc-q100"></span>
-### Question 100: What <span class="v-const">doth</span><span class="v-modern">does</span> the preface of the Lord's Prayer teach us?  
+### Question 100: What doth the preface of the Lord's Prayer teach us?  
 Answer: The preface of the Lord's Prayer, which is, Our Father <span class="v-const">which art</span> in heaven, <span class="v-const">teacheth</span><span class="v-modern">teaches</span> us to draw near to God with all holy reverence and confidence,<sup class="proof-marker">r</sup> as children to a father,<sup class="proof-marker">s</sup> able and ready to help us;<sup class="proof-marker">t</sup> and that we should pray with and for others.<sup class="proof-marker">u</sup>
 
 <details class="scripture-proofs" id="wsc-q100-proofs">
@@ -1230,7 +1230,7 @@ Answer: In the sixth petition, which is, And lead us not into temptation, but de
 
 
 <span id="wsc-q107"></span>
-### Question 107: What <span class="v-const">doth</span><span class="v-modern">does</span> the conclusion of the Lord's Prayer teach us?  
+### Question 107: What doth the conclusion of the Lord's Prayer teach us?  
 Answer: The conclusion of the Lord's Prayer, which is, For <span class="v-const">thine</span><span class="v-modern">yours</span> is the <span class="v-const">kingdom,</span><span class="v-modern">kingdom</span> and the <span class="v-const">power,</span><span class="v-modern">power</span> and the glory, forever. Amen, <span class="v-const">teacheth</span><span class="v-modern">teaches</span> us to take our encouragement in prayer from God only, and in our prayers to praise him, ascribing kingdom, power, and glory to him;<sup class="proof-marker">l</sup> and, in testimony of our desire, and assurance to be heard, we say, Amen.<sup class="proof-marker">m</sup>
 
 <details class="scripture-proofs" id="wsc-q107-proofs">

--- a/assets/gitbook/custom.js
+++ b/assets/gitbook/custom.js
@@ -85,9 +85,23 @@ require(['gitbook', 'jquery'], function(gitbook, $) {
         }, 2000);
     }
 
+    // ── Re-tag Bible references after GitBook AJAX page navigation ──────────
+    // GitBook swaps page content in via XMLHttpRequest without a full reload,
+    // so RefTagger (which auto-runs only once on first load) never re-scans
+    // the new content. Re-invoke refTagger.tag() on every page change.
+    function retagReferences() {
+        if (window.refTagger && typeof window.refTagger.tag === 'function') {
+            window.refTagger.tag();
+        }
+    }
+
     // ── Page load: restore state ───────────────────────────────────────────
     gitbook.events.bind('page.change', function() {
         applyVersionState();
+        // RefTagger.js may still be loading on the very first page.change;
+        // a short retry covers that race without blocking later navigations.
+        retagReferences();
+        setTimeout(retagReferences, 600);
     });
 
     // ── Toolbar Buttons ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up fixes to the 2025 MESV version toggle (merged in #6). These address three issues discovered after that merge. Rebased cleanly onto the current `master`.

## Changes

**1. Keep question headings as plain text**
The sidebar table-of-contents injects raw heading HTML, so the `v-const`/`v-modern` toggle spans in `### Question` headings rendered *both* versions stacked in the navigation (e.g. "doth" / "does" on separate lines). Headings also feed the search index and page metadata. Stripped the version spans from all 93 question headings (30 WSC + 63 WLC), keeping the constitutional text. Answer bodies retain the full version toggle, so the MESV switch still works for the substance of each answer.

**2. Re-run RefTagger after GitBook AJAX navigation**
The GitBook theme swaps page content via `XMLHttpRequest` without a full reload, but RefTagger auto-scans the DOM only once on initial load. Scripture-reference tooltips therefore appeared only on the first full page load and were missing after navigating between pages via the sidebar. Bound to the existing `page.change` event and call `refTagger.tag()` to re-scan, with a short retry to cover the race where RefTagger.js is still loading on the first navigation.

**3. Normalize verse-range dashes to hyphens**
RefTagger recognizes verse ranges written with a plain hyphen (`Rom. 2:14-15`) but not an en-dash (`Rom. 2:14–15`), so ranges were only partially tagged. Converted all en-dashes to hyphens within the Scripture Proof callouts (1,411 occurrences across WCF/WSC/WLC). Scoped strictly to the `proofs-body` blocks; no prose typography is affected.

## Test plan

- [ ] Sidebar TOC shows each question on one line (no stacked "doth"/"does")
- [ ] Navigate home → WCF/WSC/WLC via sidebar, expand a Scripture Proofs callout — references become RefTagger links with tooltips
- [ ] Verse ranges tag as full ranges (e.g. `Rom. 2:14-15`, cross-chapter `Rom. 1:32-2:1`)
- [ ] Version toggle still switches answer text between constitutional and MESV
- [ ] All three color themes render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLLqphvFpDoUWTAip7D6w8)_