### PR TITLE
Tag scripture references when a proof callout is expanded

### DIFF
--- a/assets/gitbook/custom.js
+++ b/assets/gitbook/custom.js
@@ -95,6 +95,22 @@ require(['gitbook', 'jquery'], function(gitbook, $) {
         }
     }
 
+    // ── Re-tag when a Scripture Proofs callout is expanded ─────────────────
+    // Every scripture reference lives inside a collapsed <details> callout.
+    // RefTagger only tags *rendered* text (via innerText), so references
+    // hidden in a closed <details> are never seen on the initial scan. When a
+    // callout opens, its references become visible for the first time, so
+    // re-run RefTagger to tag them. The 'toggle' event does not bubble, so we
+    // listen in the capture phase at the document level; this one listener
+    // also covers callouts inserted later by GitBook's AJAX navigation.
+    document.addEventListener('toggle', function(e) {
+        var el = e.target;
+        if (el && el.tagName === 'DETAILS' && el.open &&
+            el.classList.contains('scripture-proofs')) {
+            retagReferences();
+        }
+    }, true);
+
     // ── Page load: restore state ───────────────────────────────────────────
     gitbook.events.bind('page.change', function() {
         applyVersionState();


### PR DESCRIPTION
## Summary

Fixes RefTagger appearing completely non-functional. Every scripture reference on the site lives inside a **collapsed `<details>` "Scripture Proofs" callout**. RefTagger tags only *rendered* text (it reads `innerText`), and text inside a closed `<details>` is not rendered — so RefTagger's initial scan never sees a single reference, and no tooltips ever appear.

This also explains the "regression": references were tagged fine when they were inline, and stopped once they were moved into collapsible callouts.

## Verification

Confirmed the mechanism in a headless Chromium run:

```
CLOSED  innerText:   "Proofs"                              ← references hidden
CLOSED  textContent: "ProofsRom. 2:14-15; John 17:3"      ← present in DOM only
OPENED  innerText:   "Proofs\n\nRom. 2:14-15; John 17:3"   ← now visible
```

## Change

`assets/gitbook/custom.js` — add a capture-phase `toggle` listener at the document level that calls `refTagger.tag()` when a `details.scripture-proofs` callout opens, tagging its now-visible references. Capture phase is required because the `toggle` event does not bubble; a single document-level listener also covers callouts inserted by GitBook's AJAX page navigation.

## Test plan

- [ ] Open a WCF/WSC/WLC page, expand a "Scripture Proofs" callout — the references become RefTagger links with hover tooltips
- [ ] Expand a second callout — its references also get tagged
- [ ] Navigate to another standards page via the sidebar, expand a callout — still works
- [ ] Confirm no double-tagging of references in already-open callouts

## Note

If RefTagger still shows nothing after this deploys, the next thing to check is whether a browser ad-blocker is blocking `api.reftagger.com` (some blocklists include it) — that would be environmental rather than a site issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLLqphvFpDoUWTAip7D6w8)_