### PR TITLE
Make search return every matching section, not just the first per page

### DIFF
--- a/assets/gitbook/gitbook-plugin-search-pro/search.js
+++ b/assets/gitbook/gitbook-plugin-search-pro/search.js
@@ -58,13 +58,24 @@ require([
 
             var $title = $('<h3>');
 
+            // Build the href so the ?h= highlight query sits BEFORE any
+            // #section-anchor (index entries are now per-section and their
+            // url may include a fragment, e.g. /pages/wcf/#wcf-1-1).
+            var hParam = '?h=' + encodeURIComponent(res.query);
+            var hashPos = item.url.indexOf('#');
+            var href = hashPos === -1
+                ? item.url + hParam
+                : item.url.slice(0, hashPos) + hParam + item.url.slice(hashPos);
+
             var $link = $('<a>', {
-                'href': item.url + '?h=' + encodeURIComponent(res.query),
+                'href': href,
                 'text': item.title,
                 'data-is-search': 1
             });
 
-            if ($link[0].href.split('?')[0] === location.href.split('?')[0]) {
+            // Reload when the target is the page we're already on (so the
+            // highlight re-runs), comparing paths only — ignore query/hash.
+            if ($link[0].pathname === location.pathname) {
                 $link[0].setAttribute('data-need-reload', 1);
             }
 
@@ -202,6 +213,16 @@ require([
         });
 
         setTimeout(function() {
+            // Prefer the section anchor from the deep link, so the user lands
+            // on the exact matched section; fall back to the first highlight.
+            if (location.hash && location.hash.length > 1) {
+                var target = document.getElementById(
+                    decodeURIComponent(location.hash.slice(1)));
+                if (target) {
+                    target.scrollIntoView();
+                    return;
+                }
+            }
             var mark = $('mark[data-markjs="true"]');
             if (mark.length) {
                 mark[0].scrollIntoView();

--- a/assets/search_plus_index.json
+++ b/assets/search_plus_index.json
@@ -71,16 +71,50 @@ layout: null
     {%- endunless -%}
   {%- endfor -%}
 {%- endfor -%}
-{
+{%- comment -%}
+  Build a flat list of JSON "key": {...} entry strings, then join with commas.
+  Documents that carry <span id="..."></span> section anchors (WCF/WSC/WLC) are
+  split into one entry per section so search returns every matching section with
+  a deep link; all other documents become a single whole-page entry.
+{%- endcomment -%}
+{%- assign entries = "" | split: "" -%}
 {%- for document in index -%}
-  {%- assign tags = document.tags | uniq -%}
-  {%- assign categories = document.categories | uniq -%}
-  {%- assign taxonomies = tags | concat: categories | uniq -%}
-  {{ document.url | relative_url | jsonify }}: {
-    "title": {{ document.title | smartify | strip_html | normalize_whitespace | jsonify }},
-    "keywords": {{ taxonomies | join: " " | normalize_whitespace | jsonify }},
-    "url": {{ document.url | relative_url | jsonify }},
-    "body": {{ document.content | strip_html | normalize_whitespace | jsonify }}
-  }{%- unless forloop.last -%},{%- endunless -%}
+  {%- assign doctitle = document.title | smartify | strip_html | normalize_whitespace -%}
+  {%- if document.content contains '<span id="' -%}
+    {%- assign chunks = document.content | split: '<span id="' -%}
+    {%- for chunk in chunks -%}
+      {%- if forloop.first -%}
+        {%- assign preamble = chunk | strip_html | normalize_whitespace | strip -%}
+        {%- if preamble != "" -%}
+          {%- capture entry -%}{{ document.url | relative_url | jsonify }}: {"title": {{ doctitle | jsonify }}, "keywords": "", "url": {{ document.url | relative_url | jsonify }}, "body": {{ preamble | jsonify }}}{%- endcapture -%}
+          {%- assign entries = entries | push: entry -%}
+        {%- endif -%}
+      {%- else -%}
+        {%- assign secid = chunk | split: '"' | first -%}
+        {%- assign marker = secid | append: '"></span>' -%}
+        {%- assign body = chunk | remove_first: marker | strip_html | normalize_whitespace | strip -%}
+        {%- assign securl = document.url | append: '#' | append: secid -%}
+        {%- assign idparts = secid | split: '-' -%}
+        {%- if idparts[0] == 'wcf' -%}
+          {%- assign seclabel = 'Chapter ' | append: idparts[1] | append: '.' | append: idparts[2] -%}
+        {%- elsif idparts[0] == 'wsc' or idparts[0] == 'wlc' -%}
+          {%- assign qnum = idparts[1] | remove: 'q' -%}
+          {%- assign seclabel = 'Question ' | append: qnum -%}
+        {%- else -%}
+          {%- assign seclabel = secid -%}
+        {%- endif -%}
+        {%- assign sectitle = doctitle | append: ' — ' | append: seclabel -%}
+        {%- capture entry -%}{{ securl | relative_url | jsonify }}: {"title": {{ sectitle | jsonify }}, "keywords": "", "url": {{ securl | relative_url | jsonify }}, "body": {{ body | jsonify }}}{%- endcapture -%}
+        {%- assign entries = entries | push: entry -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- else -%}
+    {%- assign tags = document.tags | uniq -%}
+    {%- assign categories = document.categories | uniq -%}
+    {%- assign taxonomies = tags | concat: categories | uniq -%}
+    {%- capture entry -%}{{ document.url | relative_url | jsonify }}: {"title": {{ doctitle | jsonify }}, "keywords": {{ taxonomies | join: " " | normalize_whitespace | jsonify }}, "url": {{ document.url | relative_url | jsonify }}, "body": {{ document.content | strip_html | normalize_whitespace | jsonify }}}{%- endcapture -%}
+    {%- assign entries = entries | push: entry -%}
+  {%- endif -%}
 {%- endfor -%}
-}
+{%- assign json_out = entries | join: "," | prepend: "{" | append: "}" -%}
+{{ json_out }}


### PR DESCRIPTION
## Summary

Search only ever returned the **first match per document**. The index (`search_plus_index.json`) held one entry per page — WCF, WSC, and WLC were each a single ~100KB `body` — and `query()` in search-pro does one `indexOf()` per entry, so a term appearing in dozens of sections surfaced a single result at the first occurrence.

This rebuilds the index at **section granularity** for the three standards and updates the search plugin so the resulting deep links work.

## Changes

**`assets/search_plus_index.json`** (Liquid template)
- For documents with `<span id="…"></span>` section anchors (WCF/WSC/WLC), split the content on those anchors and emit **one index entry per section/question**, keyed by `url#anchor` with a readable title (e.g. `Westminster Confession of Faith — Chapter 1.3`, `Westminster Shorter Catechism — Question 5`).
- Documents without anchors (creeds, forms of government/discipline) remain a single whole-page entry.
- Result: **484 entries** (171 WCF + 107 WSC + 196 WLC sections + a page-level preamble each + 9 other docs), 474 of them deep-linked.

**`assets/gitbook/gitbook-plugin-search-pro/search.js`**
- Build result hrefs so the `?h=` highlight query is placed **before** the `#section-anchor` (e.g. `/pages/wcf/?h=grace#wcf-1-1`), instead of appending `?h=` after the fragment.
- Decide the "reload current page" case by `pathname` only (ignoring query/hash).
- On arrival, scroll to the anchored **section** when present, falling back to the first highlight.

## Impact (measured on a local build)

| term | before | after |
|------|-------:|------:|
| grace | ≤3 | 104 |
| baptism | ≤3 | 24 |
| justification | ≤3 | 18 |
| Sabbath | ≤3 | 16 |

## Verification

Built the site locally with Jekyll 4.4.1:
- Generated index is **valid JSON**, all **484 keys unique**
- Every sampled deep-link anchor (`wcf-1-1`, `wcf-3-5`, `wcf-33-2`, …) exists in the built HTML
- Page-level preamble entries contain only the pre-anchor heading (no duplication of section text)
- Documents without anchors still produce a single entry

## Test plan

- [ ] Search a common term (e.g. "grace", "faith") — many results appear, spanning multiple WCF/WSC/WLC sections
- [ ] Each result title names the section (e.g. "… — Question 5") and clicking it jumps to that exact section with the term highlighted
- [ ] Searching from the sidebar overlay and from the dedicated search page both work
- [ ] A term in a non-standards page (e.g. a creed) still returns that page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLLqphvFpDoUWTAip7D6w8)_