### PR TITLE
Site-wide section search + robustness/accessibility fixes

### DIFF
--- a/_includes/toc-date.html
+++ b/_includes/toc-date.html
@@ -25,7 +25,7 @@
 
     <nav role="navigation">
         <div id="book-search-input" role="search">
-            <input type="text" placeholder="Type to search" />
+            <input type="text" placeholder="Type to search" aria-label="Search this site" title="Search this site" />
         </div>
         <div id="book-search-input-link" role="search">
             <a href="{{site.baseurl}}/assets/search.html">Click to Search</a>

--- a/_pages/heidelberg.md
+++ b/_pages/heidelberg.md
@@ -20,7 +20,7 @@ Answer: First, how great my sins and misery are;[1] second, how I am delivered f
 [1] Rom. 3:9, 10; I John 1:10. [2] John 17:3; Acts 4:12; 10:43. [3] Matt. 5:16; Rom. 6:13; Eph. 5:8-10; I Pet. 2:9, 10.
 
 
-## 3.Question: From where do you know your sins and misery?
+## 3. Question: From where do you know your sins and misery?
 
 Answer: From the law of God.[1]
 

--- a/assets/gitbook/custom-local.css
+++ b/assets/gitbook/custom-local.css
@@ -158,7 +158,7 @@ a.section-num {
     vertical-align: super;
     text-decoration: none;
     color: var(--proofs-summary);
-    opacity: 0.7;
+    opacity: 0.85;
     margin-right: 0.25em;
 }
 
@@ -172,7 +172,7 @@ a.proof-backlink {
     font-size: 0.85em;
     text-decoration: none;
     color: var(--proofs-summary);
-    opacity: 0.6;
+    opacity: 0.85;
     margin-left: 0.4em;
     font-style: normal;
 }
@@ -186,7 +186,7 @@ sup.proof-marker {
     font-size: 0.7em;
     font-weight: bold;
     color: var(--proofs-summary);
-    opacity: 0.7;
+    opacity: 0.9;
     margin-left: 0.05em;
     user-select: none;
 }
@@ -264,4 +264,57 @@ sup.proof-marker:hover {
 #copy-toast.show {
     opacity: 1;
     transform: translateX(-50%) translateY(0);
+}
+
+/* ── Print / PDF ───────────────────────────────────────────────────────── */
+@media print {
+    /* Hide site chrome: sidebar, header, toolbar, search, toasts */
+    .book-summary,
+    .book-header,
+    #book-search-input,
+    #book-search-input-link,
+    #book-search-results .search-results,
+    .navigation,
+    #copy-toast,
+    #mesv-version-indicator {
+        display: none !important;
+    }
+
+    /* Let the content use the full page width */
+    .book-body,
+    .body-inner,
+    .page-wrapper,
+    .page-inner {
+        position: static !important;
+        left: 0 !important;
+        right: 0 !important;
+        width: 100% !important;
+        overflow: visible !important;
+    }
+
+    /* Expand every collapsible callout so its content prints */
+    details.scripture-proofs,
+    details.commentary {
+        break-inside: avoid;
+    }
+    details.scripture-proofs > *,
+    details.commentary > * {
+        display: block !important;
+    }
+    details.scripture-proofs summary::before,
+    details.commentary summary::before {
+        content: '' !important;
+    }
+
+    /* Readable ink-friendly colors */
+    body,
+    .book.color-theme-1,
+    .book.color-theme-2 {
+        background: #fff !important;
+        color: #000 !important;
+    }
+    a { text-decoration: none; color: #000 !important; }
+
+    /* Avoid orphaned headings */
+    h1, h2, h3 { break-after: avoid; }
 }

--- a/assets/gitbook/custom.js
+++ b/assets/gitbook/custom.js
@@ -29,9 +29,20 @@ if (document.readyState === "loading") {
 
 require(['gitbook', 'jquery'], function(gitbook, $) {
 
+    // ── Safe localStorage access ───────────────────────────────────────────
+    // Safari private mode and storage-blocked contexts throw on access; an
+    // uncaught error here would abort the whole callback and disable every
+    // toolbar button, so read/write defensively.
+    function lsGet(key) {
+        try { return localStorage.getItem(key); } catch (e) { return null; }
+    }
+    function lsSet(key, val) {
+        try { localStorage.setItem(key, val); } catch (e) { /* ignore */ }
+    }
+
     // ── State ──────────────────────────────────────────────────────────────
-    var showModern = localStorage.getItem('mesv-version') === 'modern';
-    var highlightOn = localStorage.getItem('mesv-highlight') === 'on';
+    var showModern = lsGet('mesv-version') === 'modern';
+    var highlightOn = lsGet('mesv-highlight') === 'on';
 
     // ── Helpers ────────────────────────────────────────────────────────────
     function isStandardsPage() {
@@ -91,7 +102,11 @@ require(['gitbook', 'jquery'], function(gitbook, $) {
     // the new content. Re-invoke refTagger.tag() on every page change.
     function retagReferences() {
         if (window.refTagger && typeof window.refTagger.tag === 'function') {
-            window.refTagger.tag();
+            try {
+                window.refTagger.tag();
+            } catch (e) {
+                // A RefTagger internal error must not break page.change handling.
+            }
         }
     }
 
@@ -151,8 +166,8 @@ require(['gitbook', 'jquery'], function(gitbook, $) {
                 }
                 showModern = !showModern;
                 if (!showModern) highlightOn = false;
-                localStorage.setItem('mesv-version', showModern ? 'modern' : 'constitutional');
-                localStorage.setItem('mesv-highlight', highlightOn ? 'on' : 'off');
+                lsSet('mesv-version', showModern ? 'modern' : 'constitutional');
+                lsSet('mesv-highlight', highlightOn ? 'on' : 'off');
                 applyVersionState();
                 showToast(showModern
                     ? 'Showing: 2025 Modern English Study Version'
@@ -173,7 +188,7 @@ require(['gitbook', 'jquery'], function(gitbook, $) {
                     return;
                 }
                 highlightOn = !highlightOn;
-                localStorage.setItem('mesv-highlight', highlightOn ? 'on' : 'off');
+                lsSet('mesv-highlight', highlightOn ? 'on' : 'off');
                 getContainer().toggleClass('highlight-changes', highlightOn);
                 showToast(highlightOn ? 'Highlighting changes from constitutional text' : 'Highlights off');
             }

--- a/assets/gitbook/gitbook-plugin-search-pro/search.js
+++ b/assets/gitbook/gitbook-plugin-search-pro/search.js
@@ -79,11 +79,9 @@ require([
                 $link[0].setAttribute('data-need-reload', 1);
             }
 
-            var content = item.body.trim();
-            if (content.length > MAX_DESCRIPTION_SIZE) {
-                content = content + '...';
-            }
-            var $content = $('<p>').html(content);
+            // item.body is already a trimmed, ellipsis-bounded snippet with the
+            // keyword wrapped in a highlight span (built in query()).
+            var $content = $('<p>').html(item.body);
 
             $link.appendTo($title);
             $title.appendTo($li);
@@ -105,10 +103,30 @@ require([
             index = -1;
         for (var page in INDEX_DATA) {
             if ((index = INDEX_DATA[page].body.toLowerCase().indexOf(keyword.toLowerCase())) !== -1) {
+                var fullBody = INDEX_DATA[page].body;
+                var start = Math.max(0, index - 50);
+                var end = Math.min(fullBody.length, start + MAX_DESCRIPTION_SIZE);
+                var snippet = fullBody.substring(start, end);
+                // Trim a partial word at the start and prefix an ellipsis.
+                if (start > 0) {
+                    var firstSpace = snippet.indexOf(' ');
+                    if (firstSpace > -1 && firstSpace < 30) {
+                        snippet = snippet.slice(firstSpace + 1);
+                    }
+                    snippet = '…' + snippet;
+                }
+                // Trim a partial word at the end and append an ellipsis.
+                if (end < fullBody.length) {
+                    var lastSpace = snippet.lastIndexOf(' ');
+                    if (lastSpace > snippet.length - 30) {
+                        snippet = snippet.slice(0, lastSpace);
+                    }
+                    snippet = snippet + '…';
+                }
                 results.push({
                     url: page,
                     title: INDEX_DATA[page].title,
-                    body: INDEX_DATA[page].body.substr(Math.max(0, index - 50), MAX_DESCRIPTION_SIZE).replace(new RegExp('(' + escapeReg(keyword) + ')', 'gi'), '<span class="search-highlight-keyword">$1</span>')
+                    body: snippet.replace(new RegExp('(' + escapeReg(keyword) + ')', 'gi'), '<span class="search-highlight-keyword">$1</span>')
                 });
             }
         }
@@ -144,6 +162,10 @@ require([
             $.getJSON(url).then(function(data) {
                 INDEX_DATA = data;
                 handleUpdate();
+            }).fail(function() {
+                if (window.console) {
+                    console.error('Search index failed to load: ' + url);
+                }
             });
         }
 
@@ -180,6 +202,10 @@ require([
                 $.getJSON(url).then(function(data) {
                     INDEX_DATA = data;
                     handleUpdate();
+                }).fail(function() {
+                    if (window.console) {
+                        console.error('Search index failed to load: ' + url);
+                    }
                 });
             }
         });

--- a/assets/search.html
+++ b/assets/search.html
@@ -5,5 +5,5 @@ layout: search-base
 <!-- Slightly Modified from _layouts/home.html -->
 
 <div id="book-search-input-inside" role="search">
-    <input type="text" placeholder="Type to search" />
+    <input type="text" placeholder="Type to search" aria-label="Search this site" title="Search this site" />
 </div>

--- a/assets/search_plus_index.json
+++ b/assets/search_plus_index.json
@@ -74,8 +74,10 @@ layout: null
 {%- comment -%}
   Build a flat list of JSON "key": {...} entry strings, then join with commas.
   Documents that carry <span id="..."></span> section anchors (WCF/WSC/WLC) are
-  split into one entry per section so search returns every matching section with
-  a deep link; all other documents become a single whole-page entry.
+  split into one entry per section with a deep link. Documents without those
+  anchors but with heading tags (Heidelberg, Belgic, Canons, church order) are
+  split on their kramdown auto-id headings instead. Short documents with no
+  headings (creeds) become a single whole-page entry.
 {%- endcomment -%}
 {%- assign entries = "" | split: "" -%}
 {%- for document in index -%}
@@ -106,6 +108,42 @@ layout: null
         {%- assign sectitle = doctitle | append: ' — ' | append: seclabel -%}
         {%- capture entry -%}{{ securl | relative_url | jsonify }}: {"title": {{ sectitle | jsonify }}, "keywords": "", "url": {{ securl | relative_url | jsonify }}, "body": {{ body | jsonify }}}{%- endcapture -%}
         {%- assign entries = entries | push: entry -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- elsif document.content contains '<h' -%}
+    {%- comment -%} Split on heading tags; use kramdown auto-ids for deep links. {%- endcomment -%}
+    {%- assign chunks = document.content | split: '<h' -%}
+    {%- for chunk in chunks -%}
+      {%- if forloop.first -%}
+        {%- assign preamble = chunk | strip_html | normalize_whitespace | strip -%}
+        {%- if preamble != "" -%}
+          {%- capture entry -%}{{ document.url | relative_url | jsonify }}: {"title": {{ doctitle | jsonify }}, "keywords": "", "url": {{ document.url | relative_url | jsonify }}, "body": {{ preamble | jsonify }}}{%- endcapture -%}
+          {%- assign entries = entries | push: entry -%}
+        {%- endif -%}
+      {%- else -%}
+        {%- assign lvl = chunk | slice: 0, 1 -%}
+        {%- comment -%} Only real headings (h1-h6); skips <hr>, <header>, etc. {%- endcomment -%}
+        {%- if lvl == '1' or lvl == '2' or lvl == '3' or lvl == '4' or lvl == '5' or lvl == '6' -%}
+          {%- comment -%} Re-add the '<h' the split removed so strip_html can drop the opening tag (and its id slug) instead of leaking it as text. {%- endcomment -%}
+          {%- assign body = chunk | prepend: '<h' | strip_html | normalize_whitespace | strip -%}
+          {%- if body != "" -%}
+            {%- assign headertag = chunk | split: '>' | first -%}
+            {%- if headertag contains 'id="' -%}
+              {%- assign secid = headertag | split: 'id="' | last | split: '"' | first -%}
+              {%- assign securl = document.url | append: '#' | append: secid -%}
+            {%- else -%}
+              {%- assign securl = document.url | append: '#h' | append: forloop.index -%}
+            {%- endif -%}
+            {%- assign htext = chunk | split: '</h' | first | split: '>' | last | strip_html | normalize_whitespace | strip -%}
+            {%- if htext != "" -%}
+              {%- assign sectitle = doctitle | append: ' — ' | append: htext -%}
+            {%- else -%}
+              {%- assign sectitle = doctitle -%}
+            {%- endif -%}
+            {%- capture entry -%}{{ securl | relative_url | jsonify }}: {"title": {{ sectitle | jsonify }}, "keywords": "", "url": {{ securl | relative_url | jsonify }}, "body": {{ body | jsonify }}}{%- endcapture -%}
+            {%- assign entries = entries | push: entry -%}
+          {%- endif -%}
+        {%- endif -%}
       {%- endif -%}
     {%- endfor -%}
   {%- else -%}


### PR DESCRIPTION
## Summary

Two follow-ups from the code review:

1. **Search everywhere** — extend per-section search indexing (shipped for WCF/WSC/WLC in #9) to the remaining 9 documents.
2. **Quick wins & accessibility** — a bundle of small robustness/a11y fixes.

## 1. Section-level search for all documents

PR #9 gave per-section results only to the three standards (the docs with `<span id>` anchors). Heidelberg, Belgic, Canons of Dort, the creeds, and the church-order docs (fg/bd/dpw) were still **one giant index entry each** — so search returned only the first match per document for them.

`assets/search_plus_index.json` now has a **heading-split branch**: for documents without `<span id>` anchors but with heading tags, it splits the rendered content on kramdown's **auto-generated heading IDs** and emits one deep-linked entry per heading. **No markdown edits required.** Guards: a heading-level digit check skips `<hr>`/`<header>`, and the split-off `<h` is re-prepended before `strip_html` so heading ID slugs don't leak into the searchable body.

**Impact (local build):** index grows 484 → **826 entries**; e.g. `baptism` now returns **42 results across 10 documents**, `election` 35 across 5, each deep-linked to the exact article/question.

## 2. Robustness & accessibility

- **`custom.js`** — `localStorage` reads/writes wrapped in `lsGet`/`lsSet` try/catch (Safari private mode throws `SecurityError`, which previously would abort the whole callback and disable every toolbar button); `refTagger.tag()` wrapped in try/catch.
- **`search.js`** — `.fail()` handlers on both index loads (no more silently-dead search on a load error); search snippets trimmed to **word boundaries** with ellipses instead of cutting mid-word.
- **`custom-local.css`** — raised low-opacity proof markers / section links to meet **WCAG AA** contrast (hover affordance kept); added an **`@media print`** block that hides site chrome, expands all callouts, and uses ink-friendly colors for offline/study printing.
- **`toc-date.html`, `search.html`** — `aria-label`/`title` on the search inputs (placeholder alone isn't an accessible name).
- **`heidelberg.md`** — fixed `## 3.Question:` → `## 3. Question:` (also normalizes its anchor ID).

## Verification

Built locally with Jekyll 4.4.1:
- Generated index is **valid JSON**, all **826 keys unique**
- **All 821 deep-link anchors** exist in the built HTML (0 broken)
- Per-section body sums match the whole-doc baseline (no content duplication after the id-slug-leak fix)
- `node --check` passes on `custom.js` and `search.js`

## Test plan

- [ ] Search "comfort" or "election" — results span Heidelberg/Belgic/Canons/etc., each jumping to the exact article/question
- [ ] Search snippets read as whole words with `…`, not cut mid-word
- [ ] Toggle a Scripture Proofs callout — RefTagger still tags
- [ ] Print-preview a page — sidebar/toolbar hidden, callouts expanded, black-on-white
- [ ] Version toggle still works (and no console errors in Safari private mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLLqphvFpDoUWTAip7D6w8)_