### PR TITLE
Redesign homepage as a grouped card grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,45 +4,40 @@ title: Creeds & Confessions of the Church
 permalink: /
 ---
 
-Searchable creeds, confessions, and catechisms of the church.
+<p class="home-lead">Searchable creeds, confessions, and catechisms of the church.</p>
 
-# The Ecumenical Creeds
-[The Apostles Creed](https://normanormata.github.io/pages/apostles-creed/)<br>
-[The Athanasian Creed](https://normanormata.github.io/pages/athanasian-creed/)<br>
-[The Nicene Creed](https://normanormata.github.io/pages/nicene-creed/)<br>
+<div class="home-group">
+<h2 class="home-group-title">The Ecumenical Creeds</h2>
+<div class="home-cards">
+<a class="home-card" href="/pages/apostles-creed/"><span class="home-card-title">The Apostles Creed</span><span class="home-card-desc">The earliest ecumenical summary of the apostolic faith.</span></a>
+<a class="home-card" href="/pages/athanasian-creed/"><span class="home-card-title">The Athanasian Creed</span><span class="home-card-desc">A fifth-century creed confessing the Trinity and the Incarnation.</span></a>
+<a class="home-card" href="/pages/nicene-creed/"><span class="home-card-title">The Nicene Creed</span><span class="home-card-desc">The creed of Nicaea (325) and Constantinople (381) on the triune God.</span></a>
+</div>
+</div>
 
-# The Westminster Standards
-[The Westminster Confession of Faith](https://normanormata.github.io/pages/wcf/)
-<br>
-[The Westminster Larger Catechism](https://normanormata.github.io/pages/wlc/)
-<br>
-[The Westminster Shorter Catechism](https://normanormata.github.io/pages/wsc/)
+<div class="home-group">
+<h2 class="home-group-title">The Westminster Standards</h2>
+<div class="home-cards">
+<a class="home-card" href="/pages/wcf/"><span class="home-card-title">The Westminster Confession of Faith</span><span class="home-card-desc">The 1646 confession of the Westminster Assembly.</span></a>
+<a class="home-card" href="/pages/wlc/"><span class="home-card-title">The Westminster Larger Catechism</span><span class="home-card-desc">The Assembly's fuller catechism for teaching and preaching.</span></a>
+<a class="home-card" href="/pages/wsc/"><span class="home-card-title">The Westminster Shorter Catechism</span><span class="home-card-desc">The Assembly's concise catechism for instruction.</span></a>
+</div>
+</div>
 
-# The Three Forms of Unity
-[The Belgic Confession](https://normanormata.github.io/pages/belgic/)
-<br>
-[The Canons of Dort](https://normanormata.github.io/pages/canons-of-dort/)
-<br>
-[The Heidelberg Catechism](https://normanormata.github.io/pages/heidelberg/)
+<div class="home-group">
+<h2 class="home-group-title">The Three Forms of Unity</h2>
+<div class="home-cards">
+<a class="home-card" href="/pages/belgic/"><span class="home-card-title">The Belgic Confession</span><span class="home-card-desc">A 1561 Reformed confession from the Low Countries.</span></a>
+<a class="home-card" href="/pages/canons-of-dort/"><span class="home-card-title">The Canons of Dort</span><span class="home-card-desc">The 1619 synod's reply to the Arminian Remonstrance.</span></a>
+<a class="home-card" href="/pages/heidelberg/"><span class="home-card-title">The Heidelberg Catechism</span><span class="home-card-desc">A warm, pastoral catechism of 1563 in 129 questions.</span></a>
+</div>
+</div>
 
-# The OPC Book of Church Order 
-[The Form of Government](https://normanormata.github.io/pages/fg/)
-<br>
-[The Book of Discipline](https://normanormata.github.io/pages/bd/)
-<br>
-[The Directory for the Public Worship of God](https://normanormata.github.io/pages/dpw/)
-
-[1]: https://pages.github.com
-[2]: https://pages.github.com/themes
-[3]: https://github.com/sighingnow/jekyll-gitbook/fork
-[4]: https://github.com/allejo/jekyll-toc
-[5]: https://github.com/gitbook-plugins/gitbook-plugin-search-pro
-[6]: https://github.com/rouge-ruby/rouge/tree/master/lib/rouge/themes
-[7]: https://analytics.google.com/analytics/web/
-[8]: https://www.cnzz.com/
-[9]: https://docs.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview
-[10]: https://github.com/sighingnow/jekyll-gitbook/blob/master/gitbook/custom.css
-[11]: https://discordjs.guide/popular-topics/canvas.html#setting-up-napi-rs-canvas
-[12]: https://rubygems.org/gems/jekyll-remote-theme
-[13]: https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/adding-a-theme-to-your-github-pages-site-using-jekyll
-[14]: https://github.com/sighingnow/jekyll-gitbook/blob/master/_config.yml
+<div class="home-group">
+<h2 class="home-group-title">The OPC Book of Church Order</h2>
+<div class="home-cards">
+<a class="home-card" href="/pages/fg/"><span class="home-card-title">The Form of Government</span><span class="home-card-desc">The OPC's constitution for church order and office.</span></a>
+<a class="home-card" href="/pages/bd/"><span class="home-card-title">The Book of Discipline</span><span class="home-card-desc">The OPC's procedures for church discipline.</span></a>
+<a class="home-card" href="/pages/dpw/"><span class="home-card-title">The Directory for the Public Worship of God</span><span class="home-card-desc">The OPC's directory for corporate worship.</span></a>
+</div>
+</div>

--- a/assets/gitbook/custom-local.css
+++ b/assets/gitbook/custom-local.css
@@ -318,3 +318,86 @@ sup.proof-marker:hover {
     /* Avoid orphaned headings */
     h1, h2, h3 { break-after: avoid; }
 }
+
+/* ── Homepage grouped cards ─────────────────────────────────────────────── */
+.book {
+    --card-bg:        #f7f9fb;
+    --card-border:    #2a6496;
+    --card-title:     #17324c;
+    --card-desc:      #48586a;
+    --card-separator: #d8e2ec;
+}
+.book.color-theme-1 {
+    --card-bg:        #ede3c4;
+    --card-border:    #8b5e1a;
+    --card-title:     #5a3c10;
+    --card-desc:      #6b5230;
+    --card-separator: #c9b87a;
+}
+.book.color-theme-2 {
+    --card-bg:        #242738;
+    --card-border:    #4a90c4;
+    --card-title:     #d3e2f1;
+    --card-desc:      #9aa8ba;
+    --card-separator: #373b50;
+}
+
+.markdown-section .home-lead {
+    font-size: 1.1em;
+    color: var(--card-desc);
+    margin: 0.25em 0 1.75em 0;
+}
+
+.home-group {
+    margin: 0 0 2em 0;
+}
+
+.markdown-section .home-group-title {
+    font-size: 1.15em;
+    margin: 0 0 0.75em 0;
+    padding-bottom: 0.3em;
+    border-bottom: 2px solid var(--card-separator);
+}
+
+.home-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 0.85em;
+}
+
+.markdown-section .home-card {
+    display: flex;
+    flex-direction: column;
+    padding: 0.8em 1em;
+    background: var(--card-bg);
+    border: 1px solid var(--card-separator);
+    border-left: 3px solid var(--card-border);
+    border-radius: 0 5px 5px 0;
+    text-decoration: none;
+    transition: transform 0.12s ease, box-shadow 0.12s ease;
+}
+
+.markdown-section .home-card:hover,
+.markdown-section .home-card:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.12);
+    text-decoration: none;
+    outline: 2px solid var(--card-border);
+    outline-offset: 2px;
+}
+
+.home-card-title {
+    font-weight: 600;
+    color: var(--card-title);
+    margin-bottom: 0.3em;
+}
+
+.home-card-desc {
+    font-size: 0.85em;
+    color: var(--card-desc);
+    line-height: 1.45;
+}
+
+@media (max-width: 600px) {
+    .home-cards { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Summary

The homepage (`README.md`) already grouped the twelve documents into four categories, but only as bare headings with `<br>`-separated plain links — and the links were hard-coded to the old `normanormata.github.io` domain. This rebuilds it as a **responsive, theme-aware card grid**.

## Changes

**`README.md`**
- Each document is now a **card** with its title + a concise one-line description, grouped under: Ecumenical Creeds · Westminster Standards · Three Forms of Unity · OPC Book of Church Order.
- Links switched to **root-relative** (`/pages/wcf/`) so users stay on the current custom domain.
- Dropped the unused theme link-reference-definition block (`[1]…[14]`).
- Authored as raw HTML (kramdown passthrough) — verified no stray `<p>` wrapping.

**`assets/gitbook/custom-local.css`**
- New `--card-*` theme tokens on `.book` / `.color-theme-1` / `.color-theme-2` (mirroring the existing `--proofs-*`/`--commentary-*` pattern), covering light/sepia/night.
- `.home-cards` uses CSS grid (`repeat(auto-fill, minmax(240px, 1fr))`) that **collapses to one column** on mobile.
- Cards have a left-accent border, hover lift, and `:focus-visible` outline for keyboard users; AA-contrast title/description colors.

## Verification

- **Local Jekyll build**: clean HTML passthrough — 4 group blocks, 12 card anchors (titles + descriptions), all root-relative hrefs, no stray `<p>`.
- **Headless Chromium screenshots** at desktop (1100px) and mobile (390px) widths in all three themes: three-column grid on desktop, single column on mobile, legible in light/sepia/night with working hover/focus states.

## Test plan

- [ ] Load the homepage — documents appear as grouped cards with descriptions
- [ ] Resize to mobile — cards collapse to one column
- [ ] Switch themes (light/sepia/night) — cards remain legible
- [ ] Click a card — navigates to the correct document on the current domain
- [ ] Tab through cards — visible focus outline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLLqphvFpDoUWTAip7D6w8)_